### PR TITLE
Add Social Security (Seguridad Social) cuota tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Transaction data is fetched from the Stripe API and stored in the local SQLite d
 │   ├── excel_exporter.py          # Multi-sheet Excel report generation
 │   ├── stripe_client.py           # Stripe API wrapper (charges, fees, card country)
 │   ├── fx_rates.py                # FX rate fetching (ECB/Frankfurter), storage, conversion
-│   ├── database.py                # SQLite operations (transactions, FX rates, upload log, invoices, tax, audit)
+│   ├── database.py                # SQLite operations (transactions, FX rates, upload log, invoices, SS, tax, audit)
+│   ├── social_security.py         # SS cuota import from bank exports + DB query helpers
 │   ├── tax_models.py              # Dataclasses for Modelo303, Modelo130, OSS, 347, 349 results + AuditEntry
 │   ├── tax_engine.py              # Spanish tax computation: Modelo 303/130/349/347, OSS, calendar
 │   ├── tax_snapshot_codec.py      # Serialize/deserialize tax engine results for SQLite snapshot storage
@@ -109,6 +110,7 @@ Transaction data is fetched from the Stripe API and stored in the local SQLite d
 │   ├── invoice_upload.py          # Accounting partner (IntegraLOOP/BILOOP) integration
 │   ├── invoice_ocr_tab.py         # AI invoice extraction tab (Gemini OCR)
 │   ├── invoice_explorer.py        # Filterable table of all extracted invoices
+│   ├── social_security_tab.py     # Seguridad Social tab: import bank export + view cuotas
 │   ├── tax_obligations.py         # Tax obligations tab (Modelo 303/130/349/347, OSS)
 │   ├── tax_validation.py          # Tax validation tab (gestor-filed vs DB-computed comparison)
 │   └── tax_audit.py               # Tax audit trail tab (per-cell formula + inputs drill-down)
@@ -129,6 +131,7 @@ Transaction data is fetched from the Stripe API and stored in the local SQLite d
 │       ├── in/                    # Invoices received (PDFs)
 │       └── out/                   # Invoices produced (PDFs)
 ├── tmp/
+│   ├── social_security_bank_export.xlsx  # Bank export for SS cuotas (git-ignored, configurable)
 │   └── validation/
 │       └── validation.yaml        # Gestor-filed AEAT reference data (git-ignored)
 └── logs/                          # Rotating daily log files
@@ -202,6 +205,7 @@ Transaction data is stored in a SQLite database (`data/accounting.db`):
 - **fx_rates** — Daily ECB exchange rates (EUR/USD, EUR/GBP, EUR/CHF)
 - **upload_log** — Invoice upload tracking to prevent duplicates
 - **invoices** — AI-extracted invoice records (vendor, client, IVA/IRPF breakdown, totals, Spanish AEAT fields). Includes `geo_region`, `vat_treatment`, `activity_type`, and `supply_country` columns auto-derived from the vendor/client NIF at insert time — mirroring the `transactions` table so both sources feed the tax engine uniformly
+- **social_security_payments** — Seguridad Social cuota payments imported from bank account exports. Deduplication key: `(payment_date, amount_eur)`. Automatically included as deductible expenses in Modelo 130 box 02 (YTD)
 - **quarterly_tax_entries** — Manual tax inputs (IVA soportado, gastos deducibles, retenciones)
 - **tax_filing_status** — Filing status and computed amounts per model/quarter
 - **tax_computation_snapshots** — JSON snapshots of tax engine outputs (Modelo 303/130/OSS/349/347) written when you click **Calculate tax** in Tax Obligations
@@ -224,6 +228,48 @@ Required permissions for restricted keys (`rk_live_...`):
 - **Read balance transactions** — fee details
 
 The dashboard includes a connection tester and permission checker under **Configuration → Stripe API**.
+
+---
+
+## Seguridad Social (Social Security Cuotas)
+
+The **Seguridad Social** tab imports monthly autónomo quota payments debited from your bank account and feeds them automatically into **Modelo 130** as deductible expenses.
+
+### Data source
+
+Cuota payments are not issued as invoices — they appear as bank debits. Export your bank statement (the rows corresponding to Seguridad Social payments) to Excel or CSV and import via this tab.
+
+### Setup
+
+1. Export the relevant rows from your bank's online portal to `.xlsx` or `.csv`.
+2. Place the file anywhere accessible (default: `tmp/social_security_bank_export.xlsx`).
+3. Configure the column names in `config.json`:
+
+```json
+{
+  "social_security": {
+    "bank_export_file": "tmp/social_security_bank_export.xlsx",
+    "date_column": "Fecha",
+    "amount_column": "Importe",
+    "description_column": "Concepto",
+    "sheet_name": 0,
+    "skiprows": 0
+  }
+}
+```
+
+4. Open the **Seguridad Social** tab, verify the column mapping with **Preview file columns**, then click **Import from file**.
+
+### How it works
+
+- Amounts are stored as **positive values** in the `social_security_payments` table (debits from the bank export are negative; the importer takes the absolute value).
+- Deduplication is by `(payment_date, amount_eur)` — re-importing the same file is safe.
+- The **Modelo 130** engine sums all SS payments from January 1 through the end of the selected quarter (YTD) and includes them in **box 02 — gastos deducibles**, alongside OCR-extracted expense invoices and manual entries. Legal basis: cuotas de autónomo are fully deductible under Art. 30 LIRPF (*régimen de estimación directa*).
+- The audit trail (Tax Audit tab) records `ss_gastos` and the full list of individual payments as named inputs to the `box_02_gastos` cell.
+
+### Quarterly breakdown
+
+The tab shows per-year totals and, when a year is selected, a quarterly breakdown (Q1–Q4) so you can reconcile against the TGSS monthly receipts.
 
 ---
 
@@ -282,15 +328,16 @@ Add a `tax` section to `config.json` (see `config.json.example`), or use the **C
 
 OCR-extracted invoices (from the Invoice OCR tab) feed directly into all tax models alongside Stripe transactions:
 
-| Model | Invoice contribution |
-|-------|---------------------|
-| **Modelo 303** box_28 | IVA soportado from expense invoices (`direction='in'`) |
-| **Modelo 303** box_01 | Base from income invoices classified as `IVA_ES_21` |
-| **Modelo 130** box_01 | Subtotal from non-Stripe income invoices (`direction='out'`) |
-| **Modelo 130** box_02 | Subtotal from expense invoices (weighted by `deductible_pct`) |
-| **Modelo 130** box_07 | IRPF withheld (`irpf_amount`) on outgoing invoices |
-| **Modelo 347** | Spanish-client invoice income alongside Stripe |
-| **Modelo 349** | EU B2B invoice income alongside Stripe |
+| Model | Source | Contribution |
+|-------|--------|-------------|
+| **Modelo 303** box_28 | Expense invoices (`direction='in'`) | IVA soportado deducible |
+| **Modelo 303** box_01 | Income invoices (`IVA_ES_21`) | Base imponible devengado |
+| **Modelo 130** box_01 | Non-Stripe income invoices (`direction='out'`) | Subtotal ingresos YTD |
+| **Modelo 130** box_02 | Expense invoices (`direction='in'`) | Subtotal gastos (weighted by `deductible_pct`) YTD |
+| **Modelo 130** box_02 | `social_security_payments` table | SS cuotas YTD (fully deductible) |
+| **Modelo 130** box_07 | Outgoing invoices | IRPF withheld (`irpf_amount`) YTD |
+| **Modelo 347** | Income invoices | Spanish-client invoice income alongside Stripe |
+| **Modelo 349** | Income invoices | EU B2B invoice income alongside Stripe |
 
 Geographic classification is auto-derived from the vendor NIF (expenses) or client NIF (income) at OCR extraction time. Existing rows are backfilled automatically on database init.
 

--- a/app/social_security_tab.py
+++ b/app/social_security_tab.py
@@ -1,0 +1,222 @@
+"""Social Security (Seguridad Social) tab — import bank export and view cuotas."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+ROOT = Path(__file__).parent.parent
+
+from src.config import load_config
+from src.logger import get_logger
+from src.social_security import (
+    clear_ss_payments,
+    delete_ss_payment,
+    get_ss_payments,
+    get_ss_total_for_period,
+    load_bank_export,
+    upsert_ss_payments,
+)
+
+log = get_logger(__name__)
+
+
+def _resolve(path: str) -> Path:
+    p = Path(path)
+    return p if p.is_absolute() else ROOT / path
+
+
+def render() -> None:
+    st.header("Seguridad Social — Cuotas de autónomo")
+    st.markdown(
+        "Import Social Security (Seguridad Social) monthly quota payments from a bank "
+        "account export. Imported amounts are automatically included as deductible expenses "
+        "in **Modelo 130** (box 02 — gastos deducibles YTD)."
+    )
+
+    cfg = load_config()
+    ss_cfg = cfg.get("social_security", {})
+
+    # -------------------------------------------------------------------------
+    # Import section
+    # -------------------------------------------------------------------------
+    st.subheader("Import from bank export")
+
+    default_file = ss_cfg.get("bank_export_file", "tmp/social_security_bank_export.xlsx")
+    default_date_col = ss_cfg.get("date_column", "Fecha")
+    default_amount_col = ss_cfg.get("amount_column", "Importe")
+    default_desc_col = ss_cfg.get("description_column", "")
+    default_sheet = ss_cfg.get("sheet_name", 0)
+    default_skiprows = int(ss_cfg.get("skiprows", 0))
+
+    col1, col2 = st.columns(2)
+    with col1:
+        file_path_str = st.text_input(
+            "Bank export file path (.xlsx / .xls / .csv)",
+            value=default_file,
+            help="Path relative to the project root, or absolute. "
+                 "Configure the default in config.json → social_security.bank_export_file",
+        )
+        date_column = st.text_input("Date column name", value=default_date_col)
+        amount_column = st.text_input("Amount column name", value=default_amount_col)
+    with col2:
+        description_column = st.text_input(
+            "Description column name (optional)", value=default_desc_col
+        )
+        sheet_name_input = st.text_input(
+            "Sheet name or index (0-based)",
+            value=str(default_sheet),
+            help="Use a sheet name like 'Sheet1' or a zero-based index like '0'.",
+        )
+        skiprows = st.number_input("Skip rows at top of file", min_value=0, value=default_skiprows, step=1)
+
+    # Resolve sheet name to int if numeric
+    try:
+        sheet_name: int | str = int(sheet_name_input)
+    except ValueError:
+        sheet_name = sheet_name_input.strip()
+
+    desc_col_clean = description_column.strip() or None
+
+    file_path = _resolve(file_path_str)
+
+    # Preview
+    if st.button("Preview file columns"):
+        if not file_path.exists():
+            st.error(f"File not found: `{file_path}`")
+        else:
+            try:
+                suffix = file_path.suffix.lower()
+                if suffix in (".xlsx", ".xls", ".xlsm"):
+                    df_preview = pd.read_excel(file_path, sheet_name=sheet_name, nrows=5, skiprows=skiprows, dtype=str)
+                else:
+                    df_preview = pd.read_csv(file_path, nrows=5, skiprows=skiprows, dtype=str)
+                df_preview.columns = [str(c).strip() for c in df_preview.columns]
+                st.markdown(f"**Columns found:** {list(df_preview.columns)}")
+                st.dataframe(df_preview, use_container_width=True)
+            except Exception as exc:
+                st.error(f"Could not read file: {exc}")
+
+    st.markdown("---")
+
+    col_imp, col_clear = st.columns([2, 1])
+    with col_imp:
+        if st.button("Import from file", type="primary"):
+            if not file_path.exists():
+                st.error(f"File not found: `{file_path}`")
+            else:
+                try:
+                    rows = load_bank_export(
+                        file_path=file_path,
+                        date_column=date_column,
+                        amount_column=amount_column,
+                        description_column=desc_col_clean,
+                        sheet_name=sheet_name,
+                        skiprows=int(skiprows),
+                    )
+                    if not rows:
+                        st.warning("No valid rows found in the file. Check the column names and date/amount format.")
+                    else:
+                        inserted, skipped = upsert_ss_payments(rows, source_file=str(file_path))
+                        st.success(
+                            f"Import complete: **{inserted} new rows** imported, "
+                            f"{skipped} duplicate(s) skipped."
+                        )
+                        st.rerun()
+                except Exception as exc:
+                    st.error(f"Import failed: {exc}")
+                    log.exception("SS import error")
+
+    with col_clear:
+        if st.button("Clear all SS payments", type="secondary"):
+            clear_ss_payments()
+            st.success("All Social Security payment rows cleared.")
+            st.rerun()
+
+    # -------------------------------------------------------------------------
+    # Summary by year
+    # -------------------------------------------------------------------------
+    st.subheader("Summary by year")
+
+    all_rows = get_ss_payments()
+    if not all_rows:
+        st.info("No Social Security payments stored yet. Import a bank export above.")
+        return
+
+    df_all = pd.DataFrame(all_rows)
+    df_all["payment_date"] = pd.to_datetime(df_all["payment_date"])
+    df_all["year"] = df_all["payment_date"].dt.year
+    df_all["month"] = df_all["payment_date"].dt.month
+
+    years_available = sorted(df_all["year"].unique(), reverse=True)
+
+    summary_data = []
+    for yr in years_available:
+        df_yr = df_all[df_all["year"] == yr]
+        total = df_yr["amount_eur"].sum()
+        count = len(df_yr)
+        summary_data.append({"Year": yr, "Payments": count, "Total (€)": round(total, 2)})
+
+    st.dataframe(pd.DataFrame(summary_data), use_container_width=True, hide_index=True)
+
+    # -------------------------------------------------------------------------
+    # Detail table with optional year filter
+    # -------------------------------------------------------------------------
+    st.subheader("Payment detail")
+
+    selected_year = st.selectbox("Filter by year", options=["All"] + [str(y) for y in years_available])
+
+    if selected_year == "All":
+        df_view = df_all.copy()
+    else:
+        df_view = df_all[df_all["year"] == int(selected_year)].copy()
+
+    # Quarterly breakdown when a year is selected
+    if selected_year != "All":
+        st.markdown("**Quarterly breakdown**")
+        q_data = []
+        for q in range(1, 5):
+            months = list(range((q - 1) * 3 + 1, q * 3 + 1))
+            df_q = df_view[df_view["month"].isin(months)]
+            q_data.append({
+                "Quarter": f"Q{q}",
+                "Months": f"{months[0]}–{months[-1]}",
+                "Payments": len(df_q),
+                "Total (€)": round(df_q["amount_eur"].sum(), 2),
+            })
+        st.dataframe(pd.DataFrame(q_data), use_container_width=True, hide_index=True)
+
+    # Full detail table
+    display_cols = ["id", "payment_date", "amount_eur", "description", "source_file", "imported_at"]
+    available = [c for c in display_cols if c in df_view.columns]
+    df_display = df_view[available].rename(columns={
+        "id": "ID",
+        "payment_date": "Date",
+        "amount_eur": "Amount (€)",
+        "description": "Description",
+        "source_file": "Source file",
+        "imported_at": "Imported at",
+    }).sort_values("Date", ascending=False)
+
+    st.dataframe(df_display, use_container_width=True, hide_index=True)
+
+    # CSV export
+    csv_bytes = df_display.to_csv(index=False).encode()
+    st.download_button(
+        "Download as CSV",
+        data=csv_bytes,
+        file_name="social_security_payments.csv",
+        mime="text/csv",
+    )
+
+    # -------------------------------------------------------------------------
+    # Delete individual row
+    # -------------------------------------------------------------------------
+    with st.expander("Delete a payment row"):
+        st.markdown("Enter the **ID** of the row you want to delete (visible in the table above).")
+        del_id = st.number_input("Row ID to delete", min_value=1, step=1)
+        if st.button("Delete row", type="secondary"):
+            delete_ss_payment(int(del_id))
+            st.success(f"Row {del_id} deleted.")
+            st.rerun()

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -10,6 +10,7 @@ import streamlit as st
 
 from src.database import get_invoice_stats, get_latest_stripe_sync_at, get_transaction_count_db, init_db
 from src.fx_rates import get_latest_fx_sync_at, get_rate_count, init_fx_table
+from src.social_security import get_ss_count
 
 # Initialise database and FX table on startup
 init_db()
@@ -57,10 +58,15 @@ with st.sidebar:
     st.caption(f"Income (out):   {_inv_stats['out']['count']}")
     st.caption(f"  Income last extracted: {_out_last[:10] if _out_last else 'n/a'}")
 
+    st.markdown("**Seguridad Social** `Bank export`")
+    st.caption("SS cuota payments imported from bank account exports.")
+    _ss_count = get_ss_count()
+    st.caption(f"SS payments stored: {_ss_count}")
+
 # --- Main content: horizontal tabs ---
 (tab_welcome, tab_report, tab_browser, tab_history,
  tab_currency, tab_config, tab_invoices, tab_invoice_ocr,
- tab_invoice_explorer, tab_tax, tab_validation, tab_audit) = st.tabs([
+ tab_invoice_explorer, tab_ss, tab_tax, tab_validation, tab_audit) = st.tabs([
     "Welcome",
     "Quarter Report",
     "Transaction Browser",
@@ -70,6 +76,7 @@ with st.sidebar:
     "Invoice Upload",
     "Invoice OCR",
     "Invoice Explorer",
+    "Seguridad Social",
     "Tax Obligations",
     "Tax Validation",
     "Tax Audit",
@@ -142,6 +149,11 @@ with tab_welcome:
          "Browse and filter all OCR-extracted invoices in a single table. "
          "Filter by vendor, client, direction, date range, subtotal, category, "
          "and invoice type. Export filtered results to CSV."),
+        ("Seguridad Social",
+         "Import Seguridad Social cuota payments from a bank account export (Excel or CSV). "
+         "Stores payments in the `social_security_payments` table and automatically includes "
+         "them as deductible expenses in **Modelo 130** (box 02 — gastos deducibles YTD). "
+         "Supports quarterly breakdown and CSV export."),
         ("Tax Obligations",
          "Spanish autónomo tax filing assistant. Run **Calculate tax** to persist "
          "Modelo 303 (IVA), 130 (IRPF advance), OSS, 349 (intra-EU), and 347 "
@@ -171,6 +183,7 @@ with tab_welcome:
 
 # --- Tab imports and rendering ---
 from app.quarter_report import render as render_quarter_report
+from app.social_security_tab import render as render_social_security
 from app.tax_obligations import render as render_tax_obligations
 from app.transaction_browser import render as render_transaction_browser
 from app.history import render as render_history
@@ -205,6 +218,9 @@ with tab_invoice_ocr:
 
 with tab_invoice_explorer:
     render_invoice_explorer()
+
+with tab_ss:
+    render_social_security()
 
 with tab_tax:
     render_tax_obligations()

--- a/config.json.example
+++ b/config.json.example
@@ -16,6 +16,14 @@
     "company_id": "",
     "enabled": false
   },
+  "social_security": {
+    "bank_export_file": "tmp/social_security_bank_export.xlsx",
+    "date_column": "Fecha",
+    "amount_column": "Importe",
+    "description_column": "Concepto",
+    "sheet_name": 0,
+    "skiprows": 0
+  },
   "tax": {
     "regime": "estimacion_directa_simplificada",
     "vat_registered": true,

--- a/src/database.py
+++ b/src/database.py
@@ -365,6 +365,18 @@ def init_db(db_path: Optional[str | Path] = None) -> None:
 
             CREATE INDEX IF NOT EXISTS idx_audit_log_period
                 ON tax_audit_log(year, quarter, model, computed_at);
+
+            CREATE TABLE IF NOT EXISTS social_security_payments (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                payment_date TEXT NOT NULL,
+                amount_eur   REAL NOT NULL,
+                description  TEXT NOT NULL DEFAULT '',
+                source_file  TEXT NOT NULL DEFAULT '',
+                imported_at  TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_ss_payments_date
+                ON social_security_payments(payment_date);
         """)
         _ensure_transactions_schema(conn)
         _ensure_invoices_schema(conn)

--- a/src/social_security.py
+++ b/src/social_security.py
@@ -1,0 +1,253 @@
+"""Social Security (Seguridad Social) cuotas import from bank account exports."""
+from __future__ import annotations
+
+import sqlite3
+from datetime import date, datetime
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from src.logger import get_logger
+
+log = get_logger(__name__)
+
+_DB_PATH = Path(__file__).parent.parent / "data" / "accounting.db"
+
+
+# ---------------------------------------------------------------------------
+# Excel / CSV import helpers
+# ---------------------------------------------------------------------------
+
+def _parse_date(value) -> Optional[str]:
+    """Attempt to parse a date value to ISO string (YYYY-MM-DD)."""
+    if pd.isna(value):
+        return None
+    if isinstance(value, (datetime, date)):
+        return value.strftime("%Y-%m-%d")
+    s = str(value).strip()
+    for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%d-%m-%Y", "%d.%m.%Y", "%m/%d/%Y"):
+        try:
+            return datetime.strptime(s, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return None
+
+
+def _parse_amount(value) -> Optional[float]:
+    """Parse an amount value, stripping currency symbols and thousand-separators."""
+    if pd.isna(value):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    s = str(value).strip()
+    # Remove currency symbols and whitespace
+    for ch in ("€", "$", "£", " ", "\xa0"):
+        s = s.replace(ch, "")
+    # European decimal: replace comma with dot if needed
+    if "," in s and "." in s:
+        # Assume dot is thousand sep, comma is decimal: 1.234,56 → 1234.56
+        s = s.replace(".", "").replace(",", ".")
+    elif "," in s:
+        s = s.replace(",", ".")
+    try:
+        return abs(float(s))  # SS payments are debits (negative), store as positive
+    except ValueError:
+        return None
+
+
+def load_bank_export(
+    file_path: str | Path,
+    date_column: str,
+    amount_column: str,
+    description_column: Optional[str] = None,
+    sheet_name: int | str = 0,
+    skiprows: int = 0,
+) -> list[dict]:
+    """Read a bank export Excel/CSV file and return rows with date + amount.
+
+    Returns a list of dicts: {payment_date, amount_eur, description}.
+    Rows where date or amount cannot be parsed are skipped with a warning.
+    """
+    fp = Path(file_path)
+    if not fp.exists():
+        raise FileNotFoundError(f"Bank export not found: {fp}")
+
+    suffix = fp.suffix.lower()
+    if suffix in (".xlsx", ".xls", ".xlsm"):
+        df = pd.read_excel(fp, sheet_name=sheet_name, skiprows=skiprows, dtype=str)
+    elif suffix == ".csv":
+        df = pd.read_csv(fp, skiprows=skiprows, dtype=str)
+    else:
+        raise ValueError(f"Unsupported file format: {suffix}. Use .xlsx, .xls, or .csv")
+
+    # Normalise column names: strip whitespace
+    df.columns = [str(c).strip() for c in df.columns]
+
+    if date_column not in df.columns:
+        raise ValueError(
+            f"Date column '{date_column}' not found. Available: {list(df.columns)}"
+        )
+    if amount_column not in df.columns:
+        raise ValueError(
+            f"Amount column '{amount_column}' not found. Available: {list(df.columns)}"
+        )
+
+    rows: list[dict] = []
+    skipped = 0
+    for _, row in df.iterrows():
+        payment_date = _parse_date(row[date_column])
+        amount = _parse_amount(row[amount_column])
+        if payment_date is None or amount is None or amount == 0.0:
+            skipped += 1
+            continue
+        description = ""
+        if description_column and description_column in df.columns:
+            description = str(row[description_column]).strip() if not pd.isna(row[description_column]) else ""
+        rows.append({
+            "payment_date": payment_date,
+            "amount_eur": round(amount, 2),
+            "description": description,
+        })
+
+    if skipped:
+        log.warning("⚠️ Skipped %d rows with unparseable date/amount", skipped)
+    log.info("ℹ️ Parsed %d Social Security payment rows from %s", len(rows), fp.name)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# DB helpers (called by database.py's init_db, but also directly usable)
+# ---------------------------------------------------------------------------
+
+def get_connection(db_path: Optional[str | Path] = None) -> sqlite3.Connection:
+    """Return a sqlite3 connection with row_factory set."""
+    from src.database import _get_connection
+    return _get_connection(db_path)
+
+
+def upsert_ss_payments(
+    rows: list[dict],
+    source_file: str = "",
+    db_path: Optional[str | Path] = None,
+) -> tuple[int, int]:
+    """Insert or ignore Social Security payment rows.
+
+    Deduplication key: (payment_date, amount_eur).  If both match an existing
+    row the new row is skipped (no update, since the data is authoritative from
+    the bank and we don't want to overwrite user edits).
+
+    Returns (inserted, skipped).
+    """
+    conn = get_connection(db_path)
+    inserted = skipped = 0
+    try:
+        for row in rows:
+            existing = conn.execute(
+                "SELECT id FROM social_security_payments WHERE payment_date = ? AND amount_eur = ?",
+                (row["payment_date"], row["amount_eur"]),
+            ).fetchone()
+            if existing:
+                skipped += 1
+                continue
+            conn.execute(
+                """INSERT INTO social_security_payments
+                       (payment_date, amount_eur, description, source_file)
+                   VALUES (?, ?, ?, ?)""",
+                (row["payment_date"], row["amount_eur"], row.get("description", ""), source_file),
+            )
+            inserted += 1
+        conn.commit()
+        log.info("ℹ️ SS payments: %d inserted, %d skipped (duplicates)", inserted, skipped)
+    finally:
+        conn.close()
+    return inserted, skipped
+
+
+def get_ss_payments(
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    db_path: Optional[str | Path] = None,
+) -> list[dict]:
+    """Return Social Security payment rows, optionally filtered by date range."""
+    conn = get_connection(db_path)
+    try:
+        where = ["1=1"]
+        params: list = []
+        if start_date:
+            where.append("payment_date >= ?")
+            params.append(start_date)
+        if end_date:
+            where.append("payment_date <= ?")
+            params.append(end_date)
+        rows = conn.execute(
+            f"SELECT * FROM social_security_payments WHERE {' AND '.join(where)} ORDER BY payment_date",
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_ss_total_for_period(
+    start_date: str,
+    end_date: str,
+    db_path: Optional[str | Path] = None,
+) -> float:
+    """Return the total SS amount paid within the given date range."""
+    conn = get_connection(db_path)
+    try:
+        row = conn.execute(
+            """SELECT COALESCE(SUM(amount_eur), 0) AS total
+               FROM social_security_payments
+               WHERE payment_date >= ? AND payment_date <= ?""",
+            (start_date, end_date),
+        ).fetchone()
+        return float(row["total"]) if row else 0.0
+    finally:
+        conn.close()
+
+
+def get_ss_total_ytd(
+    year: int,
+    quarter: int,
+    db_path: Optional[str | Path] = None,
+) -> float:
+    """Return cumulative SS total from Jan 1 through end of given quarter."""
+    import calendar
+    month_end = quarter * 3
+    last_day = calendar.monthrange(year, month_end)[1]
+    start = f"{year}-01-01"
+    end = f"{year}-{month_end:02d}-{last_day:02d}"
+    return get_ss_total_for_period(start, end, db_path)
+
+
+def get_ss_count(db_path: Optional[str | Path] = None) -> int:
+    """Return total number of SS payment rows stored."""
+    conn = get_connection(db_path)
+    try:
+        row = conn.execute("SELECT COUNT(*) AS cnt FROM social_security_payments").fetchone()
+        return int(row["cnt"]) if row else 0
+    finally:
+        conn.close()
+
+
+def delete_ss_payment(payment_id: int, db_path: Optional[str | Path] = None) -> None:
+    """Delete a single SS payment row by primary key."""
+    conn = get_connection(db_path)
+    try:
+        conn.execute("DELETE FROM social_security_payments WHERE id = ?", (payment_id,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def clear_ss_payments(db_path: Optional[str | Path] = None) -> None:
+    """Delete all Social Security payment rows (useful for re-import)."""
+    conn = get_connection(db_path)
+    try:
+        conn.execute("DELETE FROM social_security_payments")
+        conn.commit()
+        log.info("ℹ️ All Social Security payment rows cleared")
+    finally:
+        conn.close()

--- a/src/tax_engine.py
+++ b/src/tax_engine.py
@@ -464,6 +464,7 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
 
 def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> Modelo130Result:
     """Compute Modelo 130 (quarterly IRPF advance) for the given quarter."""
+    import calendar as _calendar
     import json as _json
     result = Modelo130Result(year=year, quarter=quarter)
     # Stripe income (transactions table)
@@ -486,8 +487,32 @@ def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
     )
     n_expense_invs = len(expense_invs_ytd)
 
+    # Social Security cuotas paid via bank account, YTD — fully deductible (Art. 30 LIRPF)
+    month_end = quarter * 3
+    last_day = _calendar.monthrange(year, month_end)[1]
+    ss_start = f"{year}-01-01"
+    ss_end = f"{year}-{month_end:02d}-{last_day:02d}"
+    _ss_rows = db_conn.execute(
+        """SELECT id, payment_date, amount_eur, description
+           FROM social_security_payments
+           WHERE payment_date >= ? AND payment_date <= ?
+           ORDER BY payment_date""",
+        (ss_start, ss_end),
+    ).fetchall()
+    ss_gastos = round(sum(float(r["amount_eur"]) for r in _ss_rows), 2)
+    ss_records = [
+        {
+            "source": "social_security",
+            "date": r["payment_date"],
+            "description": r["description"] or "Cuota Seguridad Social",
+            "amount_eur": round(float(r["amount_eur"]), 2),
+        }
+        for r in _ss_rows
+    ]
+
     result.box_02_gastos = round(
         inv_gastos
+        + ss_gastos
         + _get_tax_entries_total(year, quarter, "GASTOS_DEDUCIBLES", db_conn, ytd=True),
         2,
     )
@@ -585,11 +610,14 @@ def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
            ytd_through_quarter=quarter,
            records=stripe_income_records + income_inv_records),
         _a("box_02_gastos",
-           "Gastos deducibles acumulados (Q1–Qn) — facturas recibidas + entradas manuales",
+           "Gastos deducibles acumulados (Q1–Qn) — facturas recibidas + SS cuotas + entradas manuales",
            f"SUM(subtotal_eur * deductible_pct/100) FROM invoices WHERE direction='in' YTD "
+           f"+ SUM(amount_eur) FROM social_security_payments YTD "
            f"+ SUM(amount_eur) FROM quarterly_tax_entries WHERE entry_type='GASTOS_DEDUCIBLES' AND quarter<=Q{quarter}",
            result.box_02_gastos,
            inv_gastos=round(inv_gastos, 2),
+           ss_gastos=ss_gastos,
+           ss_records=ss_records,
            records=expense_inv_records),
         _a("box_03_rendimiento",
            "Rendimiento neto previo (antes de difícil justificación)",


### PR DESCRIPTION
- New src/social_security.py: imports bank account Excel/CSV exports, parses date + amount columns (handles European formats), upserts into social_security_payments table with (payment_date, amount_eur) dedup key.

- New DB table social_security_payments in src/database.py init_db().

- src/tax_engine.py: Modelo 130 compute_modelo_130() now sums SS cuotas YTD from social_security_payments and includes them in box_02_gastos (fully deductible under Art. 30 LIRPF). Audit trail records ss_gastos and individual payment records.

- New app/social_security_tab.py Streamlit tab: file path + column configuration, Preview, Import, quarterly breakdown, CSV export, per-row delete.

- app/streamlit_app.py: new Seguridad Social tab wired up; sidebar shows SS payment count.

- config.json.example: new social_security section with bank_export_file, date_column, amount_column, description_column, sheet_name, skiprows.

- README.md: new Seguridad Social section, updated Database table list, Project Structure, and Invoice data in tax calculations table.

https://claude.ai/code/session_017Csm1mmoDbAaxsoLZAXDAE