### PR TITLE
feat: add local-llm-hub extraction path for invoice OCR (#19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,16 @@ ACCOUNTING_PASSWORD=your_password_here
 # Optional (if you already have a token; sent as header "token")
 ACCOUNTING_TOKEN=your_token_here
 
-# vertex.ai / Google API key
+# Invoice OCR provider: "gemini" (default, direct google-genai path — needs
+# GOOGLE_API_KEY / Vertex ADC) or "hub" (routes PDFs through local-llm-hub at
+# http://127.0.0.1:8000 via the gemini_pro alias — no Google key needed).
+# The hub path is implemented but parked behind this flag until the hub's PDF
+# attachment bug (local-llm-hub#63) is fixed. Also settable in config.json
+# under invoice_ocr.provider.
+# INVOICE_OCR_PROVIDER=hub
+# Override the hub endpoint / model alias if needed:
+# LLM_HUB_BASE_URL=http://127.0.0.1:8000
+# LLM_HUB_MODEL=gemini_pro
+
+# vertex.ai / Google API key (only needed for the legacy "gemini" provider)
 GOOGLE_API_KEY=your-vertex-ai-studio-api-key

--- a/README.md
+++ b/README.md
@@ -521,7 +521,18 @@ ACCOUNTING_PASSWORD=your_password_here
 
 ## Invoice OCR (AI Extraction)
 
-The **Invoice OCR** tab uses Google Gemini to extract Spanish accounting data from any PDF — invoices, receipts, tickets, foreign bills — and stores the results in the `invoices` SQLite table.
+The **Invoice OCR** tab extracts Spanish accounting data from any PDF — invoices, receipts, tickets, foreign bills — and stores the results in the `invoices` SQLite table.
+
+### Extraction provider
+
+Extraction runs through one of two interchangeable backends, selected by `invoice_ocr.provider` in `config.json` (or the `INVOICE_OCR_PROVIDER` env var, or the `provider=` argument to `extract_invoice()`). Both backends share the same prompt and post-parsing, so the stored fields are identical regardless of provider.
+
+| Provider | How it calls | Credentials |
+|----------|-------------|-------------|
+| `gemini` (default) | Direct `google-genai` SDK to Gemini / Vertex AI | `GOOGLE_API_KEY` or Vertex ADC (`GOOGLE_APPLICATION_CREDENTIALS`) |
+| `hub` | local-llm-hub at `http://127.0.0.1:8000` via the Anthropic SDK and a `document` content block, model alias `gemini_pro` | none (the hub holds the Google session) |
+
+The `hub` path keeps all LLM access flowing through the local-llm-hub (central LAN access and observability) and needs no Google key on this machine. It is fully implemented but parked behind the flag until the hub's PDF-attachment reliability bug ([local-llm-hub#63](https://github.com/ferraroroberto/local-llm-hub/issues/63)) is fixed; once that lands, switch the default by setting `invoice_ocr.provider` to `hub`. Override the hub endpoint/alias with `LLM_HUB_BASE_URL` / `LLM_HUB_MODEL` if needed.
 
 ### Invoice directories
 

--- a/app/invoice_ocr_tab.py
+++ b/app/invoice_ocr_tab.py
@@ -271,13 +271,25 @@ def render() -> None:
 
     st.subheader("Invoice OCR — AI Extraction for Spanish Accounting")
 
-    # API key check
-    has_key = bool(os.getenv("GOOGLE_API_KEY"))
-    if not has_key:
-        st.error(
-            "GOOGLE_API_KEY is not set. Add it to your `.env` file to use this feature."
+    # Backend readiness check. The default "hub" provider routes through
+    # local-llm-hub and needs no Google credentials; the legacy "gemini"
+    # provider requires GOOGLE_API_KEY (or Vertex ADC).
+    from src.invoice_ocr import _resolve_provider
+
+    provider = _resolve_provider(None)
+    if provider == "gemini":
+        has_key = bool(os.getenv("GOOGLE_API_KEY")) or bool(
+            os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
         )
-        return
+        if not has_key:
+            st.error(
+                "Provider is 'gemini' but neither GOOGLE_API_KEY nor "
+                "GOOGLE_APPLICATION_CREDENTIALS is set. Add one to your `.env` "
+                "file, or set invoice_ocr.provider to 'hub' in config.json."
+            )
+            return
+    else:
+        st.caption("Extraction provider: local-llm-hub (`gemini_pro`).")
 
     st.info(
         "Upload invoices (PDFs) to the `data/invoices/in` or `data/invoices/out` directories, "

--- a/config.json.example
+++ b/config.json.example
@@ -16,6 +16,9 @@
     "company_id": "",
     "enabled": false
   },
+  "invoice_ocr": {
+    "provider": "gemini"
+  },
   "social_security": {
     "bank_export_file": "tmp/social_security_bank_export.xlsx",
     "date_column": "Fecha",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ plotly>=5.18.0
 requests>=2.31.0
 pytest>=8.0.0
 google-genai>=1.0.0
+anthropic>=0.40.0
 pyyaml>=6.0

--- a/src/invoice_ocr.py
+++ b/src/invoice_ocr.py
@@ -1,14 +1,24 @@
-"""Invoice OCR extraction via Google Gemini.
+"""Invoice OCR extraction from PDFs for Spanish accounting.
 
 Accepts any PDF (invoice, receipt, ticket, nota de gastos, etc.) and extracts
 Spanish-accounting-relevant fields, returning a structured dict ready to store
 in the `invoices` table.
 
-Uses the current `google-genai` SDK (google.genai), not the deprecated
-`google.generativeai` package.
+Two backends are supported, selected by the ``provider`` argument /
+``invoice_ocr.provider`` config key / ``INVOICE_OCR_PROVIDER`` env var:
+
+- ``"hub"`` (default) — routes the PDF + prompt through the local-llm-hub
+  (http://127.0.0.1:8000) using the Anthropic SDK and a ``document`` content
+  block, mapped to the ``gemini_pro`` alias. No Google credentials needed.
+- ``"gemini"`` — the legacy direct path via the ``google-genai`` SDK, using a
+  Vertex AI ADC service account or a Gemini API key. Kept as a fallback.
+
+Both paths share the same extraction prompt and post-parsing, so the returned
+dict schema is identical regardless of provider.
 """
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import os
@@ -19,8 +29,22 @@ from src.logger import get_logger
 
 log = get_logger(__name__)
 
-# Model: gemini-2.0-flash-lite as requested (preview variant)
+# Direct google-genai model id (legacy "gemini" provider path).
 MODEL = "gemini-3.1-flash-lite-preview"
+
+# local-llm-hub defaults (the "hub" provider path).
+HUB_BASE_URL = "http://127.0.0.1:8000"
+HUB_MODEL = "gemini_pro"  # stable alias — never the display name
+
+# Default provider for extraction. Override via config (invoice_ocr.provider)
+# or the INVOICE_OCR_PROVIDER env var.
+#
+# NOTE: this stays "gemini" until local-llm-hub#63 is fixed. The "hub" path is
+# fully implemented and works, but the hub's underlying Antigravity (`agy`)
+# CLI intermittently fails to read the attached PDF ("document not provided /
+# could not be accessed"), so routing every extraction through it would break
+# invoice OCR. Flip to "hub" once #63 is green — it is the only change needed.
+DEFAULT_PROVIDER = "gemini"
 
 _EXTRACTION_PROMPT = """
 You are an expert Spanish accountant and OCR assistant specialising in AEAT compliance.
@@ -149,20 +173,126 @@ QUALITY RULES:
 """
 
 
-def extract_invoice(pdf_path: str | Path, api_key: Optional[str] = None) -> dict:
-    """Extract accounting data from a PDF using Gemini.
+def _resolve_provider(provider: Optional[str]) -> str:
+    """Pick the extraction backend: explicit arg › env › config › default."""
+    if provider:
+        return provider.strip().lower()
+    env = os.getenv("INVOICE_OCR_PROVIDER")
+    if env:
+        return env.strip().lower()
+    try:
+        from src.config import load_config
 
-    Args:
-        pdf_path: Path to the PDF file.
-        api_key:  Google API key. Falls back to GOOGLE_API_KEY env var.
+        cfg_provider = load_config().get("invoice_ocr", {}).get("provider")
+        if cfg_provider:
+            return str(cfg_provider).strip().lower()
+    except Exception:  # config optional — fall through to default
+        log.debug("Could not read invoice_ocr.provider from config; using default.")
+    return DEFAULT_PROVIDER
 
-    Returns:
-        Parsed dict with extracted fields plus ``_raw_response`` key.
 
-    Raises:
-        RuntimeError: If google-genai is not installed, key is missing, or
-                      the API call fails.
-        FileNotFoundError: If the PDF does not exist.
+def _parse_json_object(raw_text: str) -> dict:
+    """Parse the JSON object out of a model response.
+
+    Tolerates markdown fences and any prose the model may emit before or after
+    the object. The legacy ``gemini`` path constrains output with Gemini's
+    ``response_mime_type="application/json"``; the ``hub`` path cannot pass that
+    backend-specific flag, so the model occasionally wraps the JSON in fences or
+    appends a trailing comment. We first try a strict parse, then fall back to
+    extracting the first balanced top-level ``{...}`` object.
+    """
+    clean = raw_text.strip()
+
+    # Strip wrapping markdown fences if present.
+    if clean.startswith("```"):
+        lines = clean.splitlines()
+        clean = "\n".join(
+            line for line in lines if not line.startswith("```")
+        ).strip()
+
+    try:
+        return json.loads(clean)
+    except json.JSONDecodeError:
+        pass
+
+    # Fall back: scan for the first balanced top-level object, ignoring braces
+    # inside string literals.
+    start = clean.find("{")
+    if start == -1:
+        raise ValueError("no JSON object found in response")
+    depth = 0
+    in_str = False
+    escape = False
+    for i in range(start, len(clean)):
+        ch = clean[i]
+        if in_str:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(clean[start : i + 1])
+    raise ValueError("unterminated JSON object in response")
+
+
+def _extract_via_hub(pdf_bytes: bytes, pdf_name: str) -> str:
+    """Send the PDF + prompt through local-llm-hub; return the raw model text.
+
+    Uses the Anthropic SDK shape with a ``document`` content block, routed to
+    the ``gemini_pro`` alias. The hub is the standard LAN entry point; do not
+    re-implement a CLI subprocess wrapper here.
+    """
+    try:
+        from anthropic import Anthropic
+    except ImportError as exc:
+        raise RuntimeError(
+            "anthropic package not installed. Run: pip install anthropic"
+        ) from exc
+
+    base_url = os.getenv("LLM_HUB_BASE_URL", HUB_BASE_URL)
+    model = os.getenv("LLM_HUB_MODEL", HUB_MODEL)
+    log.info("Extracting %s via local-llm-hub (%s, model=%s)…", pdf_name, base_url, model)
+
+    client = Anthropic(api_key="local-dummy", base_url=base_url)
+    pdf_b64 = base64.b64encode(pdf_bytes).decode("ascii")
+    response = client.messages.create(
+        model=model,
+        max_tokens=8192,
+        temperature=0,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "application/pdf",
+                            "data": pdf_b64,
+                        },
+                    },
+                    {"type": "text", "text": _EXTRACTION_PROMPT},
+                ],
+            }
+        ],
+    )
+    parts = [block.text for block in response.content if getattr(block, "type", None) == "text"]
+    return "".join(parts).strip()
+
+
+def _extract_via_gemini(pdf_bytes: bytes, pdf_name: str, api_key: Optional[str]) -> str:
+    """Send the PDF + prompt directly to Gemini; return the raw model text.
+
+    Legacy fallback path via ``google-genai`` (Vertex ADC or API key).
     """
     try:
         from google import genai
@@ -174,14 +304,6 @@ def extract_invoice(pdf_path: str | Path, api_key: Optional[str] = None) -> dict
         ) from exc
 
     key = api_key or os.getenv("GOOGLE_API_KEY")
-    if not key:
-        raise RuntimeError("GOOGLE_API_KEY is not set in environment or .env file.")
-
-    pdf_path = Path(pdf_path)
-    if not pdf_path.exists():
-        raise FileNotFoundError(f"PDF not found: {pdf_path}")
-
-    log.info("Extracting %s via Gemini…", pdf_path.name)
 
     # Three auth modes:
     # 1. GOOGLE_APPLICATION_CREDENTIALS set → Vertex AI with ADC (service account JSON)
@@ -192,16 +314,18 @@ def extract_invoice(pdf_path: str | Path, api_key: Optional[str] = None) -> dict
     location = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
 
     if adc_path:
-        log.info("Using Vertex AI + ADC (project=%s, location=%s)", project, location)
+        log.info(
+            "Extracting %s via Vertex AI + ADC (project=%s, location=%s)…",
+            pdf_name, project, location,
+        )
         client = genai.Client(vertexai=True, project=project, location=location)
     else:
-        log.info("Using Gemini API with API key")
+        if not key:
+            raise RuntimeError(
+                "GOOGLE_API_KEY is not set in environment or .env file."
+            )
+        log.info("Extracting %s via Gemini API with API key…", pdf_name)
         client = genai.Client(api_key=key)
-
-    # Embed PDF inline (avoids Files API; works for docs up to ~20 MB)
-    with open(pdf_path, "rb") as fh:
-        pdf_bytes = fh.read()
-    file_hash = hashlib.md5(pdf_bytes).hexdigest()
 
     response = client.models.generate_content(
         model=MODEL,
@@ -214,27 +338,62 @@ def extract_invoice(pdf_path: str | Path, api_key: Optional[str] = None) -> dict
             response_mime_type="application/json",
         ),
     )
+    return (response.text or "").strip()
 
-    raw_text = (response.text or "").strip()
-    log.debug("Gemini raw response for %s: %s", pdf_path.name, raw_text[:500])
 
-    # Strip accidental markdown fences
-    clean = raw_text
-    if clean.startswith("```"):
-        lines = clean.splitlines()
-        clean = "\n".join(
-            line for line in lines if not line.startswith("```")
-        ).strip()
+def extract_invoice(
+    pdf_path: str | Path,
+    api_key: Optional[str] = None,
+    provider: Optional[str] = None,
+) -> dict:
+    """Extract accounting data from a PDF.
+
+    Args:
+        pdf_path: Path to the PDF file.
+        api_key:  Google API key for the ``gemini`` provider. Falls back to
+                  the GOOGLE_API_KEY env var. Ignored by the ``hub`` provider.
+        provider: ``"hub"`` (default) or ``"gemini"``. Falls back to the
+                  INVOICE_OCR_PROVIDER env var, then ``invoice_ocr.provider``
+                  in config.json, then ``DEFAULT_PROVIDER``.
+
+    Returns:
+        Parsed dict with extracted fields plus ``_raw_response`` and
+        ``_file_hash`` keys. Schema is identical across providers.
+
+    Raises:
+        RuntimeError: If the chosen backend's SDK is missing, credentials are
+                      missing, or the call / JSON parse fails.
+        FileNotFoundError: If the PDF does not exist.
+    """
+    pdf_path = Path(pdf_path)
+    if not pdf_path.exists():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    with open(pdf_path, "rb") as fh:
+        pdf_bytes = fh.read()
+    file_hash = hashlib.md5(pdf_bytes).hexdigest()
+
+    resolved = _resolve_provider(provider)
+    if resolved == "hub":
+        raw_text = _extract_via_hub(pdf_bytes, pdf_path.name)
+    elif resolved == "gemini":
+        raw_text = _extract_via_gemini(pdf_bytes, pdf_path.name, api_key)
+    else:
+        raise RuntimeError(
+            f"Unknown invoice OCR provider {resolved!r}. Use 'hub' or 'gemini'."
+        )
+
+    log.debug("Raw OCR response for %s: %s", pdf_path.name, raw_text[:500])
 
     try:
-        data = json.loads(clean)
-    except json.JSONDecodeError as exc:
+        data = _parse_json_object(raw_text)
+    except (json.JSONDecodeError, ValueError) as exc:
         log.error("JSON parse failed for %s: %s\nRaw: %s", pdf_path.name, exc, raw_text)
         raise RuntimeError(
-            f"Gemini returned non-JSON for {pdf_path.name}: {exc}"
+            f"OCR backend returned non-JSON for {pdf_path.name}: {exc}"
         ) from exc
 
-    # Normalise numeric fields — Gemini sometimes returns strings like "1.234,56"
+    # Normalise numeric fields — the model sometimes returns strings like "1.234,56"
     for field in (
         "subtotal_eur", "iva_rate", "iva_amount", "irpf_rate",
         "irpf_amount", "total_eur", "original_amount", "fx_rate",


### PR DESCRIPTION
## What

Adds a local-llm-hub-backed extraction path to invoice OCR (`src/invoice_ocr.py::extract_invoice`) as a purely additive provider, alongside the existing direct `google-genai` (Vertex ADC / Gemini API key) path. Implements ferraroroberto/local-llm-hub#60 for this repo (issue #19).

## How

- New `provider` selector — explicit `provider=` arg › `INVOICE_OCR_PROVIDER` env › `invoice_ocr.provider` in `config.json` › `DEFAULT_PROVIDER`.
- `hub` path: sends the PDF + the same extraction prompt through the hub at `http://127.0.0.1:8000` using the Anthropic SDK with a base64 `document` content block (`media_type: application/pdf`), mapped to the stable alias `gemini_pro`. No Google credentials needed on this machine — the hub holds the Google session. Endpoint/alias overridable via `LLM_HUB_BASE_URL` / `LLM_HUB_MODEL`. The document-block shape matches the hub's #61 contract exactly (confirmed against `local-llm-hub/src/server.py` and `tests/test_image_blocks.py`).
- `gemini` path: unchanged behaviour, refactored into `_extract_via_gemini`.
- Both providers share the extraction prompt and post-parsing, so the stored field schema is identical regardless of provider.
- Added a tolerant JSON-object parser (`_parse_json_object`) that survives leading/trailing prose and markdown fences. The direct path relied on Gemini's `response_mime_type="application/json"` to guarantee clean JSON; that flag cannot be passed through the hub, so the hub path needs the tolerant parser. Shared by both paths.
- Invoice OCR tab gates on Google credentials only when the provider is `gemini`; the `hub` provider needs none.
- `anthropic>=0.40.0` added to `requirements.txt` (matching the file's `>=` lower-bound style). README and `.env.example` document the provider choice.

## Default stays `gemini` for now — blocked on a hub bug

The hub path is implemented and verified working, but during end-to-end testing the hub's Antigravity (`agy`) CLI **intermittently fails to read the attached PDF**: 1 of 5 consecutive real calls succeeded; the rest returned `Document @doc_0.pdf was not provided or could not be accessed in the filesystem` (null fields), and under back-to-back load `agy -p` hung entirely. Routing every extraction through the hub today would break invoice OCR, so the default is left at `gemini`.

Filed as the true blocker: **ferraroroberto/local-llm-hub#63**. Once that is green, flipping the default is a one-line change (`DEFAULT_PROVIDER = "hub"` + `config.json.example`).

## Verification

- `python -m py_compile src/invoice_ocr.py app/invoice_ocr_tab.py` — clean.
- `python -m pytest` — 88 passed.
- End-to-end against a real sample invoice (`data/invoices/in/202410 - blaze - …pdf`):
  - **hub** path returned a fully populated, schema-correct extraction (vendor "Blaze Today Inc", $8.39) on the cold call — proving the document block flows through `gemini_pro` correctly — but failed on repeat calls (the #63 bug).
  - **gemini** (default) path returned a fully populated, schema-correct extraction, all 33 expected keys present, `is_rectificativa` bool, `_file_hash`/`_raw_response` set.

Refs #19 — left open until the default is flipped (gated on local-llm-hub#63).
