### PR TITLE
feat: default invoice OCR to local-llm-hub (#19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,13 +17,11 @@ ACCOUNTING_PASSWORD=your_password_here
 # Optional (if you already have a token; sent as header "token")
 ACCOUNTING_TOKEN=your_token_here
 
-# Invoice OCR provider: "gemini" (default, direct google-genai path — needs
-# GOOGLE_API_KEY / Vertex ADC) or "hub" (routes PDFs through local-llm-hub at
-# http://127.0.0.1:8000 via the gemini_pro alias — no Google key needed).
-# The hub path is implemented but parked behind this flag until the hub's PDF
-# attachment bug (local-llm-hub#63) is fixed. Also settable in config.json
-# under invoice_ocr.provider.
-# INVOICE_OCR_PROVIDER=hub
+# Invoice OCR provider: "hub" (default, routes PDFs through local-llm-hub at
+# http://127.0.0.1:8000 via the gemini_pro alias — no Google key needed) or
+# "gemini" (legacy direct google-genai path — needs GOOGLE_API_KEY / Vertex ADC).
+# Also settable in config.json under invoice_ocr.provider.
+# INVOICE_OCR_PROVIDER=gemini
 # Override the hub endpoint / model alias if needed:
 # LLM_HUB_BASE_URL=http://127.0.0.1:8000
 # LLM_HUB_MODEL=gemini_pro

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Transaction data is fetched from the Stripe API and stored in the local SQLite d
 │   ├── tax_snapshot_codec.py      # Serialize/deserialize tax engine results for SQLite snapshot storage
 │   ├── tax_validator.py           # Validation: compare gestor-filed AEAT figures vs DB-computed values
 │   ├── accounting_api_client.py   # IntegraLOOP/BILOOP Accounting API client
-│   ├── invoice_ocr.py             # Gemini-powered PDF extraction for Spanish accounting
+│   ├── invoice_ocr.py             # PDF extraction for Spanish accounting (local-llm-hub default, direct Gemini fallback)
 │   ├── logger.py                  # Rotating file logger
 │   └── exceptions.py              # Custom exception classes
 ├── app/                           # Streamlit dashboard
@@ -108,7 +108,7 @@ Transaction data is fetched from the Stripe API and stored in the local SQLite d
 │   ├── currency.py                # FX rate management, charts, and conversion tool
 │   ├── configuration.py           # Rules editor, Stripe API key, tax settings, cache
 │   ├── invoice_upload.py          # Accounting partner (IntegraLOOP/BILOOP) integration
-│   ├── invoice_ocr_tab.py         # AI invoice extraction tab (Gemini OCR)
+│   ├── invoice_ocr_tab.py         # AI invoice extraction tab (OCR via local-llm-hub / Gemini)
 │   ├── invoice_explorer.py        # Filterable table of all extracted invoices
 │   ├── social_security_tab.py     # Seguridad Social tab: import bank export + view cuotas
 │   ├── tax_obligations.py         # Tax obligations tab (Modelo 303/130/349/347, OSS)
@@ -529,10 +529,10 @@ Extraction runs through one of two interchangeable backends, selected by `invoic
 
 | Provider | How it calls | Credentials |
 |----------|-------------|-------------|
-| `gemini` (default) | Direct `google-genai` SDK to Gemini / Vertex AI | `GOOGLE_API_KEY` or Vertex ADC (`GOOGLE_APPLICATION_CREDENTIALS`) |
-| `hub` | local-llm-hub at `http://127.0.0.1:8000` via the Anthropic SDK and a `document` content block, model alias `gemini_pro` | none (the hub holds the Google session) |
+| `hub` (default) | local-llm-hub at `http://127.0.0.1:8000` via the Anthropic SDK and a `document` content block, model alias `gemini_pro` | none (the hub holds the Google session) |
+| `gemini` | Direct `google-genai` SDK to Gemini / Vertex AI | `GOOGLE_API_KEY` or Vertex ADC (`GOOGLE_APPLICATION_CREDENTIALS`) |
 
-The `hub` path keeps all LLM access flowing through the local-llm-hub (central LAN access and observability) and needs no Google key on this machine. It is fully implemented but parked behind the flag until the hub's PDF-attachment reliability bug ([local-llm-hub#63](https://github.com/ferraroroberto/local-llm-hub/issues/63)) is fixed; once that lands, switch the default by setting `invoice_ocr.provider` to `hub`. Override the hub endpoint/alias with `LLM_HUB_BASE_URL` / `LLM_HUB_MODEL` if needed.
+The `hub` path is the default: it keeps all LLM access flowing through the local-llm-hub (central LAN access and observability) and needs no Google key on this machine. It became the default once the hub's PDF-attachment reliability bug ([local-llm-hub#63](https://github.com/ferraroroberto/local-llm-hub/issues/63)) was fixed — the hub now passes attachment dirs via `agy --add-dir`, so document/PDF blocks ingest deterministically. Override the hub endpoint/alias with `LLM_HUB_BASE_URL` / `LLM_HUB_MODEL` if needed. To fall back to the legacy direct Gemini/Vertex path, set `invoice_ocr.provider` to `gemini` (or `INVOICE_OCR_PROVIDER=gemini`).
 
 ### Invoice directories
 

--- a/config.json.example
+++ b/config.json.example
@@ -17,7 +17,7 @@
     "enabled": false
   },
   "invoice_ocr": {
-    "provider": "gemini"
+    "provider": "hub"
   },
   "social_security": {
     "bank_export_file": "tmp/social_security_bank_export.xlsx",

--- a/src/invoice_ocr.py
+++ b/src/invoice_ocr.py
@@ -39,12 +39,13 @@ HUB_MODEL = "gemini_pro"  # stable alias — never the display name
 # Default provider for extraction. Override via config (invoice_ocr.provider)
 # or the INVOICE_OCR_PROVIDER env var.
 #
-# NOTE: this stays "gemini" until local-llm-hub#63 is fixed. The "hub" path is
-# fully implemented and works, but the hub's underlying Antigravity (`agy`)
-# CLI intermittently fails to read the attached PDF ("document not provided /
-# could not be accessed"), so routing every extraction through it would break
-# invoice OCR. Flip to "hub" once #63 is green — it is the only change needed.
-DEFAULT_PROVIDER = "gemini"
+# Defaults to "hub": every LLM call flows through local-llm-hub for central LAN
+# access and observability, and no Google credentials are needed on this machine.
+# The hub's PDF-attachment reliability bug (local-llm-hub#63) is fixed — the hub
+# now passes attachment dirs via `agy --add-dir`, so document/PDF blocks ingest
+# deterministically. The legacy "gemini" (Vertex / API-key) path remains fully
+# intact as a selectable fallback.
+DEFAULT_PROVIDER = "hub"
 
 _EXTRACTION_PROMPT = """
 You are an expert Spanish accountant and OCR assistant specialising in AEAT compliance.


### PR DESCRIPTION
Closes #19.

Flips the invoice-OCR extraction default from the legacy direct Gemini/Vertex path to the local-llm-hub path, so a fresh clone routes PDF extraction through the hub (central LAN access + observability, no Google credentials needed on this machine). The hub-backed path itself was already built and merged behind the provider flag in #20 — this is the surgical default-flip that completes the routing work.

This was unblocked by local-llm-hub#63 (merged as local-llm-hub PR #64): the hub now passes attachment dirs to the Antigravity (`agy`) CLI via `agy --add-dir`, so PDF/document content blocks ingest deterministically. Previously the default was intentionally parked on `gemini` because `agy` intermittently failed to read the attached PDF.

## Change
- `src/invoice_ocr.py`: `DEFAULT_PROVIDER` `"gemini"` → `"hub"` (plus the now-stale parked-behind-#63 comment rewritten).
- `config.json.example` and `.env.example`: default provider documented as `hub`; the commented opt-out now shows `gemini` as the fallback.
- `README.md`: provider table and prose updated — `hub` is the default, `gemini` the selectable fallback; file-tree comments made provider-neutral.

The legacy Vertex / API-key (`gemini`) path is left fully intact and selectable via `invoice_ocr.provider` / `INVOICE_OCR_PROVIDER` / the `provider=` arg. Provider resolution order is unchanged: arg › `INVOICE_OCR_PROVIDER` env › `invoice_ocr.provider` config › `DEFAULT_PROVIDER`.

## Verification
- `py_compile` clean; full suite **88 passed**.
- End-to-end against the live hub (`gemini_pro`, #63 fix loaded) on the real Blaze invoice fixture, with **no** provider arg and **no** `INVOICE_OCR_PROVIDER` env — so it exercises the new default. Confirmed `_resolve_provider(None) == "hub"` and a full 34-key (33 documented + 2 meta) schema-correct extraction: vendor `Blaze Today Inc`, invoice `7944F09A-0018`, date `2024-10-05`, USD currency with `original_amount 8.39` (EUR fields correctly null for a USD invoice), category `SOFTWARE`. Ran **3 consecutive times** with identical, fully-populated results — reliability confirmed now that #63 is fixed.