### PR TITLE
refactor: extract vat_rules.py as single source of truth for VAT matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Transaction data is fetched from the Stripe API and stored in the local SQLite d
 │   ├── database.py                # SQLite operations (transactions, FX rates, upload log, invoices, SS, tax, audit)
 │   ├── social_security.py         # SS cuota import from bank exports + DB query helpers
 │   ├── tax_models.py              # Dataclasses for Modelo303, Modelo130, OSS, 347, 349 results + AuditEntry
+│   ├── vat_rules.py               # Single source of truth: activity×geo VAT matrix, OSS rates, base extraction
 │   ├── tax_engine.py              # Spanish tax computation: Modelo 303/130/349/347, OSS, calendar
 │   ├── tax_snapshot_codec.py      # Serialize/deserialize tax engine results for SQLite snapshot storage
 │   ├── tax_validator.py           # Validation: compare gestor-filed AEAT figures vs DB-computed values

--- a/app/invoice_upload.py
+++ b/app/invoice_upload.py
@@ -36,6 +36,87 @@ def _get_new_invoices(all_files: list[str], uploaded: list[dict]) -> list[str]:
     return [f for f in all_files if f not in uploaded_names]
 
 
+def _render_upload_panel(
+    direction: str,
+    doc_type: str,
+    invoice_dir: str,
+    client: "AccountingAPIClient | None",
+    api_enabled: bool,
+) -> None:
+    """Render one invoice-upload tab (scan → metrics → upload → history).
+
+    ``direction`` is ``"in"`` (received) or ``"out"`` (produced); ``doc_type`` is
+    the accounting-partner document type (``"buy_invoices"`` / ``"sell_invoices"``).
+    """
+    label = "Invoices Received" if direction == "in" else "Invoices Produced"
+    st.subheader(label)
+    st.caption(f"Directory: `{invoice_dir}`")
+
+    dir_path = ROOT / invoice_dir
+    dir_path.mkdir(parents=True, exist_ok=True)
+
+    all_files = _scan_invoices(invoice_dir)
+    uploaded = get_uploaded_files(direction)
+    new_files = _get_new_invoices(all_files, uploaded)
+
+    col_total, col_uploaded, col_new = st.columns(3)
+    col_total.metric("Total PDFs", len(all_files))
+    col_uploaded.metric("Already Uploaded", len(uploaded))
+    col_new.metric("New (pending)", len(new_files))
+
+    if new_files:
+        st.markdown("**New invoices to upload:**")
+        for f in new_files:
+            st.markdown(f"- `{f}`")
+
+        if st.button(
+            f"Upload new invoices ({direction.capitalize()})",
+            key=f"upload_{direction}",
+            disabled=not api_enabled,
+        ):
+            if not client:
+                st.error("Accounting API client not configured.")
+            else:
+                token = st.session_state.get("inv_api_token") or (os.getenv("ACCOUNTING_TOKEN") or "")
+                if not token:
+                    st.error("No token available. Set ACCOUNTING_TOKEN or fetch token.")
+                else:
+                    progress = st.progress(0, text="Uploading...")
+                    uploaded_count = 0
+                    for i, filename in enumerate(new_files):
+                        try:
+                            path = str((dir_path / filename).resolve())
+                            res = client.upload_document(
+                                token=token,
+                                doc_type=doc_type,
+                                file_path=path,
+                                date=datetime.now(),
+                                year=datetime.now().year,
+                                overwrite=0,
+                            )
+                            record_upload(filename, direction, api_response=str(res)[:2000])
+                            uploaded_count += 1
+                            progress.progress((i + 1) / len(new_files), text=f"Uploaded {filename}")
+                        except AccountingAPIError as exc:
+                            log.error("Invoice upload failed for %s: %s", filename, exc)
+                            record_upload(filename, direction, api_response=f"ERROR: {exc}")
+                            st.error(f"{filename}: {exc}")
+                    progress.empty()
+                    st.success(f"Uploaded {uploaded_count}/{len(new_files)} invoices")
+                    st.rerun()
+    else:
+        st.success("All invoices have been uploaded.")
+
+    if uploaded:
+        st.markdown("---")
+        st.markdown("**Upload history:**")
+        st.dataframe(
+            pd.DataFrame(uploaded),
+            width="stretch",
+            hide_index=True,
+        )
+
+
 def render():
     """Render the Invoice Upload tab."""
     cfg = load_config()
@@ -214,129 +295,7 @@ def render():
     in_tab, out_tab = st.tabs(["Invoices Received (In)", "Invoices Produced (Out)"])
 
     with in_tab:
-        st.subheader("Invoices Received")
-        st.caption(f"Directory: `{invoice_in_dir}`")
-
-        in_dir_path = ROOT / invoice_in_dir
-        in_dir_path.mkdir(parents=True, exist_ok=True)
-
-        all_in = _scan_invoices(invoice_in_dir)
-        uploaded_in = get_uploaded_files("in")
-        new_in = _get_new_invoices(all_in, uploaded_in)
-
-        col_total, col_uploaded, col_new = st.columns(3)
-        col_total.metric("Total PDFs", len(all_in))
-        col_uploaded.metric("Already Uploaded", len(uploaded_in))
-        col_new.metric("New (pending)", len(new_in))
-
-        if new_in:
-            st.markdown("**New invoices to upload:**")
-            for f in new_in:
-                st.markdown(f"- `{f}`")
-
-            if st.button("Upload new invoices (In)", key="upload_in", disabled=not api_enabled):
-                if not client:
-                    st.error("Accounting API client not configured.")
-                else:
-                    token = st.session_state.get("inv_api_token") or (os.getenv("ACCOUNTING_TOKEN") or "")
-                    if not token:
-                        st.error("No token available. Set ACCOUNTING_TOKEN or fetch token.")
-                    else:
-                        progress = st.progress(0, text="Uploading...")
-                        uploaded_count = 0
-                        for i, filename in enumerate(new_in):
-                            try:
-                                path = str((in_dir_path / filename).resolve())
-                                res = client.upload_document(
-                                    token=token,
-                                    doc_type="buy_invoices",
-                                    file_path=path,
-                                    date=datetime.now(),
-                                    year=datetime.now().year,
-                                    overwrite=0,
-                                )
-                                record_upload(filename, "in", api_response=str(res)[:2000])
-                                uploaded_count += 1
-                                progress.progress((i + 1) / len(new_in), text=f"Uploaded {filename}")
-                            except AccountingAPIError as exc:
-                                log.error("Invoice upload failed for %s: %s", filename, exc)
-                                record_upload(filename, "in", api_response=f"ERROR: {exc}")
-                                st.error(f"{filename}: {exc}")
-                        progress.empty()
-                        st.success(f"Uploaded {uploaded_count}/{len(new_in)} invoices")
-                        st.rerun()
-        else:
-            st.success("All invoices have been uploaded.")
-
-        if uploaded_in:
-            st.markdown("---")
-            st.markdown("**Upload history:**")
-            st.dataframe(
-                pd.DataFrame(uploaded_in),
-                width="stretch",
-                hide_index=True,
-            )
+        _render_upload_panel("in", "buy_invoices", invoice_in_dir, client, api_enabled)
 
     with out_tab:
-        st.subheader("Invoices Produced")
-        st.caption(f"Directory: `{invoice_out_dir}`")
-
-        out_dir_path = ROOT / invoice_out_dir
-        out_dir_path.mkdir(parents=True, exist_ok=True)
-
-        all_out = _scan_invoices(invoice_out_dir)
-        uploaded_out = get_uploaded_files("out")
-        new_out = _get_new_invoices(all_out, uploaded_out)
-
-        col_total, col_uploaded, col_new = st.columns(3)
-        col_total.metric("Total PDFs", len(all_out))
-        col_uploaded.metric("Already Uploaded", len(uploaded_out))
-        col_new.metric("New (pending)", len(new_out))
-
-        if new_out:
-            st.markdown("**New invoices to upload:**")
-            for f in new_out:
-                st.markdown(f"- `{f}`")
-
-            if st.button("Upload new invoices (Out)", key="upload_out", disabled=not api_enabled):
-                if not client:
-                    st.error("Accounting API client not configured.")
-                else:
-                    token = st.session_state.get("inv_api_token") or (os.getenv("ACCOUNTING_TOKEN") or "")
-                    if not token:
-                        st.error("No token available. Set ACCOUNTING_TOKEN or fetch token.")
-                    else:
-                        progress = st.progress(0, text="Uploading...")
-                        uploaded_count = 0
-                        for i, filename in enumerate(new_out):
-                            try:
-                                path = str((out_dir_path / filename).resolve())
-                                res = client.upload_document(
-                                    token=token,
-                                    doc_type="sell_invoices",
-                                    file_path=path,
-                                    date=datetime.now(),
-                                    year=datetime.now().year,
-                                    overwrite=0,
-                                )
-                                record_upload(filename, "out", api_response=str(res)[:2000])
-                                uploaded_count += 1
-                                progress.progress((i + 1) / len(new_out), text=f"Uploaded {filename}")
-                            except AccountingAPIError as exc:
-                                log.error("Invoice upload failed for %s: %s", filename, exc)
-                                record_upload(filename, "out", api_response=f"ERROR: {exc}")
-                                st.error(f"{filename}: {exc}")
-                        progress.empty()
-                        st.success(f"Uploaded {uploaded_count}/{len(new_out)} invoices")
-                        st.rerun()
-        else:
-            st.success("All invoices have been uploaded.")
-
-        if uploaded_out:
-            st.markdown("---")
-            st.markdown("**Upload history:**")
-            st.dataframe(
-                pd.DataFrame(uploaded_out),
-                width="stretch",
-                hide_index=True,
-            )
+        _render_upload_panel("out", "sell_invoices", invoice_out_dir, client, api_enabled)

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -172,43 +172,21 @@ def classify_vat(payment: ClassifiedPayment, config: Optional[dict] = None) -> C
     The payment is returned with updated VAT fields (mutated copy via model_copy).
     """
     from src.tax_models import OSS_RATES
+    from src.vat_rules import vat_amount_on_base, vat_treatment
 
-    tax_cfg = (config or {}).get("tax", {})
     activity = payment.activity_type
     geo = payment.geo_region
-    base = payment.net_amount  # net_amount already in EUR
+    base = payment.net_amount  # net_amount already in EUR (taxable base, not gross)
 
-    treatment: str
-    vat_amount = 0.0
+    treatment = vat_treatment(activity, geo, config)
     oss_country: Optional[str] = None
+    cc = (payment.card_country or "").upper()
 
-    if geo == "OUTSIDE_EU":
-        treatment = "IVA_EXPORT"
+    if treatment == "OSS_EU":
+        # Use card_country for OSS country assignment (only when it has a known rate)
+        oss_country = cc if cc in OSS_RATES else None
 
-    elif geo == "SPAIN":
-        treatment = "IVA_ES_21"
-        vat_amount = round(base * 0.21, 2)
-
-    elif geo == "EU_NOT_SPAIN":
-        if activity == "NEWSLETTER":
-            treatment = "OSS_EU"
-            # Use card_country for OSS country assignment
-            cc = (payment.card_country or "").upper()
-            oss_country = cc if cc in OSS_RATES else None
-            rate = OSS_RATES.get(cc, OSS_RATES["DEFAULT_EU"])
-            vat_amount = round(base * rate, 2)
-        else:
-            # COACHING and ILLUSTRATIONS default to B2B reverse charge
-            eu_b2b_treatment = tax_cfg.get(
-                f"default_vat_treatment_eu_{activity.lower()}", "IVA_EU_B2B"
-            )
-            treatment = eu_b2b_treatment
-            # 0% for reverse charge
-            vat_amount = 0.0
-
-    else:
-        # UNKNOWN geo
-        treatment = "UNKNOWN"
+    vat_amount = vat_amount_on_base(base, treatment, cc)
 
     return payment.model_copy(update={
         "vat_treatment": treatment,

--- a/src/tax_engine.py
+++ b/src/tax_engine.py
@@ -9,7 +9,6 @@ from typing import Optional
 from src.logger import get_logger
 from src.models import ClassifiedPayment
 from src.tax_models import (
-    OSS_RATES,
     AuditEntry,
     Modelo130Result,
     Modelo303Result,
@@ -22,6 +21,12 @@ from src.tax_models import (
     TaxDeadline,
     VATTreatment,
     _tax_deadline_date,
+)
+from src.vat_rules import (
+    oss_rate,
+    vat_amount_on_base,
+    vat_base_from_inclusive,
+    vat_treatment,
 )
 
 log = get_logger(__name__)
@@ -198,22 +203,22 @@ def _net_amount(row: dict) -> float:
 
 
 def _get_vat_treatment(row: dict) -> str:
-    """Return stored vat_treatment, or derive it on-the-fly if missing."""
+    """Return stored vat_treatment, or derive it on-the-fly if missing.
+
+    The fallback derivation delegates to the shared treatment matrix in
+    ``src.vat_rules`` so the classifier and the engine cannot diverge. No
+    ``config`` is passed here, so the EU B2B fallback is the default
+    ``IVA_EU_B2B`` (matching the historical engine behaviour).
+    """
     stored = row.get("vat_treatment")
     if stored and stored != "UNKNOWN":
         return stored
     # Derive from activity × geo (fallback for rows not yet VAT-classified)
-    geo = row.get("geo_region") or "UNKNOWN"
-    activity = row.get("activity_type") or "UNKNOWN"
-    if geo == "OUTSIDE_EU":
-        return "IVA_EXPORT"
-    if geo == "SPAIN":
-        return "IVA_ES_21"
-    if geo == "EU_NOT_SPAIN":
-        if activity == "NEWSLETTER":
-            return "OSS_EU"
-        return "IVA_EU_B2B"
-    return "UNKNOWN"
+    return vat_treatment(row.get("activity_type"), row.get("geo_region"))
+
+
+def _oss_country_code(row: dict) -> str:
+    return (row.get("oss_country") or row.get("card_country") or "").upper()
 
 
 def _get_vat_base(row: dict) -> float:
@@ -226,30 +231,17 @@ def _get_vat_base(row: dict) -> float:
     """
     if row.get("vat_base_eur") is not None:
         return row["vat_base_eur"]
-    net = _net_amount(row)
-    treatment = _get_vat_treatment(row)
-    if treatment == "IVA_ES_21":
-        return round(net / 1.21, 2)
-    if treatment == "OSS_EU":
-        cc = (row.get("oss_country") or row.get("card_country") or "").upper()
-        rate = OSS_RATES.get(cc, OSS_RATES["DEFAULT_EU"])
-        return round(net / (1 + rate), 2)
-    # IVA_EXPORT, IVA_EU_B2B, EXEMPT, UNKNOWN — full net amount is income base
-    return net
+    return vat_base_from_inclusive(
+        _net_amount(row), _get_vat_treatment(row), _oss_country_code(row)
+    )
 
 
 def _get_vat_amount(row: dict) -> float:
     if row.get("vat_amount_eur") is not None:
         return row["vat_amount_eur"]
-    treatment = _get_vat_treatment(row)
-    base = _get_vat_base(row)
-    if treatment == "IVA_ES_21":
-        return round(base * 0.21, 2)
-    if treatment == "OSS_EU":
-        cc = (row.get("oss_country") or row.get("card_country") or "").upper()
-        rate = OSS_RATES.get(cc, OSS_RATES["DEFAULT_EU"])
-        return round(base * rate, 2)
-    return 0.0
+    return vat_amount_on_base(
+        _get_vat_base(row), _get_vat_treatment(row), _oss_country_code(row)
+    )
 
 
 def _get_tax_entries_total(
@@ -816,7 +808,7 @@ def compute_oss_return(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
         by_country[cc]["vat"] += vat
 
     for country, data in sorted(by_country.items()):
-        rate = OSS_RATES.get(country, OSS_RATES["DEFAULT_EU"])
+        rate = oss_rate(country)
         result.rows.append(OSSCountryRow(
             country=country,
             transactions=data["count"],

--- a/src/vat_rules.py
+++ b/src/vat_rules.py
@@ -1,0 +1,97 @@
+"""Single source of truth for the VAT treatment decision matrix and rates.
+
+The activity × geography → ``vat_treatment`` matrix, the OSS rate lookup, and
+the VAT-inclusive base extraction were previously implemented twice — once on
+the Pydantic model in :func:`src.classifier.classify_vat`, and again as a
+fallback in ``src.tax_engine._get_vat_treatment`` / ``_get_vat_base`` /
+``_get_vat_amount``. Divergence between the two copies would produce inconsistent
+figures between what gets stored on a transaction and what the engine recomputes.
+
+This module holds the rules once. It depends only on ``src.tax_models`` (for the
+OSS rate table) so it can be imported from both the classifier and the tax engine
+without a circular import.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from src.tax_models import OSS_RATES
+
+# Standard Spanish IVA rate.
+IVA_ES_RATE = 0.21
+
+
+def oss_rate(country_code: Optional[str]) -> float:
+    """Return the OSS VAT rate for an EU destination country code.
+
+    Falls back to ``DEFAULT_EU`` for unknown or missing codes.
+    """
+    cc = (country_code or "").upper()
+    return OSS_RATES.get(cc, OSS_RATES["DEFAULT_EU"])
+
+
+def vat_treatment(
+    activity: Optional[str],
+    geo: Optional[str],
+    config: Optional[dict] = None,
+) -> str:
+    """Derive the ``vat_treatment`` from the activity × geography matrix.
+
+    The single rule set:
+
+    - ``OUTSIDE_EU`` → ``IVA_EXPORT``
+    - ``SPAIN`` → ``IVA_ES_21``
+    - ``EU_NOT_SPAIN`` + ``NEWSLETTER`` → ``OSS_EU``
+    - ``EU_NOT_SPAIN`` + other activity → EU B2B reverse charge. The treatment
+      may be overridden per-activity via
+      ``tax.default_vat_treatment_eu_<activity>`` in ``config``; defaults to
+      ``IVA_EU_B2B``.
+    - anything else → ``UNKNOWN``
+
+    ``config`` is the full app config dict (with a ``tax`` section). When
+    ``None``, the EU B2B default ``IVA_EU_B2B`` is used.
+    """
+    geo = geo or "UNKNOWN"
+    activity = activity or "UNKNOWN"
+
+    if geo == "OUTSIDE_EU":
+        return "IVA_EXPORT"
+    if geo == "SPAIN":
+        return "IVA_ES_21"
+    if geo == "EU_NOT_SPAIN":
+        if activity == "NEWSLETTER":
+            return "OSS_EU"
+        tax_cfg = (config or {}).get("tax", {})
+        return tax_cfg.get(
+            f"default_vat_treatment_eu_{activity.lower()}", "IVA_EU_B2B"
+        )
+    return "UNKNOWN"
+
+
+def vat_base_from_inclusive(
+    net: float, treatment: str, country_code: Optional[str] = None
+) -> float:
+    """Extract the ex-VAT taxable base from a VAT-inclusive (gross) net amount.
+
+    Stripe amounts are VAT-inclusive (the customer paid the gross amount). For
+    Spain (``IVA_ES_21``) and EU B2C (``OSS_EU``) the base is ``net / (1 + rate)``.
+    For exports and EU B2B (reverse charge) no VAT was charged, so the full net
+    amount is the income base.
+    """
+    if treatment == "IVA_ES_21":
+        return round(net / (1 + IVA_ES_RATE), 2)
+    if treatment == "OSS_EU":
+        return round(net / (1 + oss_rate(country_code)), 2)
+    # IVA_EXPORT, IVA_EU_B2B, EXEMPT, UNKNOWN — full net amount is income base
+    return net
+
+
+def vat_amount_on_base(
+    base: float, treatment: str, country_code: Optional[str] = None
+) -> float:
+    """Return the VAT cuota charged on an ex-VAT base for a given treatment."""
+    if treatment == "IVA_ES_21":
+        return round(base * IVA_ES_RATE, 2)
+    if treatment == "OSS_EU":
+        return round(base * oss_rate(country_code), 2)
+    return 0.0


### PR DESCRIPTION
## Summary

- Add `src/vat_rules.py` as the canonical home for the activity × geography → VAT treatment matrix, OSS rate lookup, VAT-inclusive base extraction, and VAT amount calculation — replacing two parallel implementations that could silently diverge.
- `src/classifier.py`: `classify_vat()` now delegates to `vat_treatment()` and `vat_amount_on_base()` from `vat_rules`; the inline matrix is removed.
- `src/tax_engine.py`: `_get_vat_treatment()`, `_get_vat_base()`, `_get_vat_amount()` now delegate to `vat_rules`; the duplicated OSS rate lookups and base calculations are removed. A divergence between the stored classifier output and the engine's fallback recomputation is now structurally impossible.
- `app/invoice_upload.py`: extract `_render_upload_panel(direction, doc_type, invoice_dir, client, api_enabled)` helper, collapsing the two near-identical ~45-line In/Out upload blocks into two single-line call sites.
- `README.md`: add `vat_rules.py` to the `src/` file-tree listing.

## Validation

Gate: `py_compile` clean + `pytest` — **88 passed** (includes the correctness-sensitive `test_classifier.py` and `test_tax_engine.py` covering the full VAT matrix, OSS rates, and base-extraction logic).

Closes #11