### PR TITLE
chore: remove 4 stale dead-code findings from audit

### DIFF
--- a/app/tax_validation.py
+++ b/app/tax_validation.py
@@ -94,24 +94,9 @@ def _render_model_section(result: ModelValidationResult) -> None:
 
     df = _lines_to_df(result.lines)
 
-    # Colour the Status column using pandas Styler
-    def colour_status(row):
-        colour = _STATUS_COLOURS.get(row["_status"], "#888888")
-        styles = [""] * len(row)
-        idx = list(row.index).index("Status")
-        styles[idx] = f"color: {colour}; font-weight: bold"
-        # Also colour diff column
-        diff_idx = list(row.index).index("Diff (DB − filed)")
-        styles[diff_idx] = f"color: {colour}"
-        return styles
-
     display_df = df.drop(columns=["_status"])
-    styled = (
-        display_df.style
-        .apply(colour_status, axis=1, subset=None)  # can't easily apply on drop, use lambda
-    )
 
-    # Fallback: just render plain table with colour in Status cell via map
+    # Colour the Status and Diff columns via per-cell map
     def highlight_status(val: str) -> str:
         for key, colour in _STATUS_COLOURS.items():
             if key in val:

--- a/src/aggregator.py
+++ b/src/aggregator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import calendar
 from collections import defaultdict
 from datetime import date
 from typing import Optional
@@ -79,11 +80,6 @@ def build_monthly_table(
     for y, m in relevant_months:
         a = agg_map.get((y, m), MonthlyAggregation(year=y, month=m, geo_region=geo_filter))
         month_start = date(y, m, 1)
-        if m == 12:
-            month_end = date(y + 1, 1, 1)
-        else:
-            month_end = date(y, m + 1, 1)
-        import calendar
         last_day = calendar.monthrange(y, m)[1]
         month_end = date(y, m, last_day)
 

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -9,11 +9,6 @@ from src.rules_engine import load_rules
 
 log = get_logger(__name__)
 
-MONTH_LABELS = {
-    1: "Jan", 2: "Feb", 3: "Mar", 4: "Apr", 5: "May", 6: "Jun",
-    7: "Jul", 8: "Aug", 9: "Sep", 10: "Oct", 11: "Nov", 12: "Dec",
-}
-
 
 def classify_activity(
     description: str,

--- a/src/tax_models.py
+++ b/src/tax_models.py
@@ -27,16 +27,7 @@ OSS_RATES: dict[str, float] = {
     "DEFAULT_EU": 0.21,
 }
 
-TAX_DEADLINES: dict[str, dict | str] = {
-    "303": {1: "April 20", 2: "July 20", 3: "October 20", 4: "January 30 (next year)"},
-    "130": {1: "April 20", 2: "July 20", 3: "October 20", 4: "January 30 (next year)"},
-    "390": "January 30 (following year)",
-    "347": "February 28 (following year)",
-    "349": {1: "April 20", 2: "July 20", 3: "October 20", 4: "January 20 (next year)"},
-    "OSS": {1: "April 30", 2: "July 31", 3: "October 31", 4: "January 31 (next year)"},
-}
-
-# Actual deadline dates per model / quarter for status computation
+# Deadline dates per model / quarter for status computation
 def _tax_deadline_date(model: str, year: int, quarter: int) -> date:
     """Return the actual deadline date for a given tax model, year, and quarter."""
     if model in ("303", "130", "349"):


### PR DESCRIPTION
## Summary

- Delete dead `colour_status` closure and `styled` Styler in `app/tax_validation.py` — `styled2` is the only path that reaches `st.dataframe`
- Delete `TAX_DEADLINES` dict in `src/tax_models.py` — never referenced; `_tax_deadline_date()` independently hard-codes the same dates
- Delete `MONTH_LABELS` in `src/classifier.py` — unused; `MONTH_NAMES` in `aggregator.py` is the live equivalent
- Remove dead first `month_end` computation in `src/aggregator.py:build_monthly_table` (immediately overwritten); hoist `import calendar` to module scope

No behaviour change. Pure dead-code removal.

## Validation

- `py_compile` on all 4 changed files: SYNTAX OK
- `pytest`: 88/88 passed (0 failures, 0 skips)
- `git diff main...HEAD`: exactly the 4 deletions, nothing outside issue scope

Closes #12