### PR TITLE
refactor: hoist box_29 inline ternary into named locals

### DIFF
--- a/src/tax_engine.py
+++ b/src/tax_engine.py
@@ -403,13 +403,12 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
         + _get_tax_entries_total(year, quarter, "IVA_SOPORTADO", db_conn, ytd=False),
         2,
     )
-    result.box_29_base_soportado = round(
-        inv_base_soportado
-        + (result.box_28_iva_soportado - inv_iva_soportado) / 0.21
-        if (result.box_28_iva_soportado - inv_iva_soportado) > 0
-        else inv_base_soportado,
-        2,
-    )
+    manual_iva = result.box_28_iva_soportado - inv_iva_soportado
+    if manual_iva > 0:
+        manual_base = manual_iva / 0.21
+        result.box_29_base_soportado = round(inv_base_soportado + manual_base, 2)
+    else:
+        result.box_29_base_soportado = round(inv_base_soportado, 2)
 
     # Round accumulations
     result.box_01_base = round(result.box_01_base, 2)


### PR DESCRIPTION
## Summary

- Extracts `manual_iva = box_28_iva_soportado - inv_iva_soportado` into a named local, eliminating the triple-recomputed sub-expression in the old inline ternary.
- Guards the estimated manual base on its own line (`if manual_iva > 0`), making the two branches explicit and auditable at a glance.
- The computed value for `box_29_base_soportado` (Modelo 303 IVA-soportado base) is **unchanged** — this is a pure readability refactor.

## Validation

- **Syntax:** `py_compile src/tax_engine.py` — OK
- **Unit tests:** `pytest` — 88 passed, 0 failures
- **Numerical equivalence:** standalone probe comparing original formula vs refactored formula across 6 test cases covering both branches (manual_iva > 0, == 0, < 0) — ALL MATCH
- **Diff scope:** only `src/tax_engine.py`, only the 7-line block identified in the issue — no unintended changes

Closes #13