### PR TITLE
fix: remove duplicate DB helpers from fx_rates

### DIFF
--- a/src/fx_rates.py
+++ b/src/fx_rates.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import requests
 
+from src.database import _get_connection, _get_table_columns
 from src.logger import get_logger
 
 log = get_logger(__name__)
@@ -19,13 +20,6 @@ FRANKFURTER_BASES = [
     "https://api.frankfurter.dev",
 ]
 SUPPORTED_CURRENCIES = ["USD", "GBP", "CHF"]
-
-_DB_PATH = Path(__file__).parent.parent / "data" / "accounting.db"
-
-
-def _get_table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
-    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
-    return {r["name"] for r in rows}
 
 
 def _ensure_fx_schema(conn: sqlite3.Connection) -> None:
@@ -61,14 +55,6 @@ def _get_with_fallback(path: str, *, params: dict[str, str], timeout_s: int = 30
             continue
     assert last_exc is not None
     raise last_exc
-
-
-def _get_connection(db_path: Optional[str | Path] = None) -> sqlite3.Connection:
-    path = Path(db_path) if db_path else _DB_PATH
-    path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(path))
-    conn.row_factory = sqlite3.Row
-    return conn
 
 
 def init_fx_table(db_path: Optional[str | Path] = None) -> None:


### PR DESCRIPTION
## Summary

- `src/fx_rates.py` had its own `_get_connection` and `_get_table_columns` that duplicated the canonical versions in `src/database.py`.
- The local `_get_connection` was missing the `PRAGMA journal_mode=WAL` and `PRAGMA foreign_keys=ON` that `database._get_connection` sets — so every FX-table connection ran with different SQLite semantics than the rest of the app.
- `social_security.py` already follows the correct pattern (imports `_get_connection` from `src.database`).
- Fix: import both helpers from `src.database`; delete the local copies and the now-unused `_DB_PATH` constant.

## Validation

- `py_compile src/fx_rates.py` — OK
- `pytest tests/` — 88/88 passed (14 FX-rate tests, 9 database tests, all green)
- `git diff main...HEAD` reviewed — only the three removals + one import line, nothing outside scope

Closes #25
