### PR TITLE
chore: fix stale Gemini references and remove dead stripe function

### DIFF
--- a/.claude/commands/gestor.md
+++ b/.claude/commands/gestor.md
@@ -110,7 +110,7 @@ Estás trabajando dentro del repositorio `accounting-quarterly`, una herramienta
 - Clasificación automática de transacciones (`src/classifier.py`, `classification_rules.json`)
 - Exportación de modelos 303, 130, 347, 349 y OSS
 - Validación contra datos presentados al gestor (`app/tax_validation.py`)
-- OCR de facturas con Gemini (`src/invoice_ocr.py`)
+- OCR de facturas vía local-llm-hub (Gemini como fallback) (`src/invoice_ocr.py`)
 
 Cuando el usuario pregunta sobre el código, combinas tu rol de gestor con el conocimiento técnico del repositorio para dar respuestas que sean tanto fiscalmente correctas como técnicamente implementables.
 

--- a/app/invoice_ocr_tab.py
+++ b/app/invoice_ocr_tab.py
@@ -1,4 +1,4 @@
-"""Invoice OCR tab — extract accounting data from PDFs via Gemini."""
+"""Invoice OCR tab — extract accounting data from PDFs via the configured OCR backend."""
 from __future__ import annotations
 
 import json
@@ -58,7 +58,7 @@ def _needs_extraction(filename: str, direction: str, invoice_dir: str) -> bool:
 
 
 def _extract_and_save(filename: str, direction: str, invoice_dir: str) -> dict:
-    """Run Gemini extraction and persist to DB. Returns the extracted data dict."""
+    """Run extraction via the configured OCR backend and persist to DB. Returns the extracted data dict."""
     from src.invoice_ocr import extract_invoice
 
     pdf_path = _resolve_dir(invoice_dir) / filename
@@ -242,7 +242,7 @@ def _render_invoice_fields(rec: dict) -> None:
             st.markdown("**Notes**")
             st.info(rec["notes"])
 
-    with st.expander("Raw Gemini JSON", expanded=False):
+    with st.expander("Raw extraction JSON", expanded=False):
         raw = rec.get("raw_json") or "{}"
         try:
             st.json(json.loads(raw))
@@ -293,7 +293,7 @@ def render() -> None:
 
     st.info(
         "Upload invoices (PDFs) to the `data/invoices/in` or `data/invoices/out` directories, "
-        "then click **Extract** to parse them via Gemini and store the accounting data in the "
+        "then click **Extract** to parse them via the configured OCR backend and store the accounting data in the "
         "`invoices` table.\n\n"
         "- **In (expenses):** invoices you received — IVA soportado, deductible costs.\n"
         "- **Out (income):** invoices you issued — IVA repercutido, income."

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -155,7 +155,8 @@ with tab_welcome:
          "have already been uploaded, and sends only new ones."),
         ("Invoice OCR",
          "AI-powered extraction of Spanish accounting data from any PDF "
-         "(invoice, receipt, ticket). Uses Google Gemini to parse vendor, "
+         "(invoice, receipt, ticket). Routes through the configured OCR backend "
+         "(local-llm-hub by default, Gemini as fallback) to parse vendor, "
          "client, IVA, IRPF, and totals, and stores results in the `invoices` "
          "table. Supports in (expenses) and out (income) documents."),
         ("Invoice Explorer",

--- a/src/stripe_client.py
+++ b/src/stripe_client.py
@@ -188,26 +188,3 @@ def check_permissions(api_key: Optional[str] = None) -> dict[str, bool]:
             permissions[resource_name] = False
 
     return permissions
-
-
-def fetch_charge_with_card_country(charge_id: str,
-                                    api_key: Optional[str] = None) -> Optional[str]:
-    """Fetch the card issuing country for a specific charge.
-
-    Returns ISO 3166-1 alpha-2 country code (e.g., 'ES', 'DE', 'US') or None.
-    The card country is available in charge.payment_method_details.card.country
-    when the payment was made with a card. This requires 'Read charges' permission.
-    """
-    try:
-        stripe = _get_stripe()
-        stripe.api_key = api_key or get_stripe_api_key()
-        charge = stripe.Charge.retrieve(charge_id)
-        pmd = getattr(charge, "payment_method_details", None)
-        if pmd:
-            card = getattr(pmd, "card", None)
-            if card:
-                return getattr(card, "country", None)
-        return None
-    except Exception as exc:
-        log.warning("⚠️ Could not fetch card country for %s: %s", charge_id, exc)
-        return None


### PR DESCRIPTION
## Summary

- Replace all stale `via Gemini` / `Google Gemini` UI strings with provider-neutral wording across `app/invoice_ocr_tab.py` (module docstring, `_extract_and_save` docstring, expander header, info-box) and `app/streamlit_app.py` (welcome-tab description) — these all contradicted the caption already printed by `render()` which correctly shows the active backend as `local-llm-hub`.
- Update `.claude/commands/gestor.md` line 113 to reflect `local-llm-hub` as the active OCR backend (Gemini as fallback), matching the README.
- Remove dead `fetch_charge_with_card_country()` from `src/stripe_client.py` — zero callers in `app/`, `src/`, or `tests/`; card-country is already pulled inline in `fetch_charges()`.

## Validation

- `py_compile` on all 3 changed Python files — PASS
- `pytest` — 88 passed, 0 failed, 0 skipped
- `git diff main...HEAD` sanity sweep — 7 targeted edits, nothing outside stated scope
- Confirmed no callers of removed function via grep across the repo

Closes #26
