### PR TITLE
chore: remove dead per-transaction VAT classification path

### DIFF
--- a/src/classifier.py
+++ b/src/classifier.py
@@ -160,47 +160,6 @@ def classify_batch(
     return classified, error_ids
 
 
-def classify_vat(payment: ClassifiedPayment, config: Optional[dict] = None) -> ClassifiedPayment:
-    """Assign vat_treatment, vat_base_eur, vat_amount_eur, and oss_country to a ClassifiedPayment.
-
-    Rules are derived from the activity × geography matrix in the tax specification.
-    The payment is returned with updated VAT fields (mutated copy via model_copy).
-    """
-    from src.tax_models import OSS_RATES
-    from src.vat_rules import vat_amount_on_base, vat_treatment
-
-    activity = payment.activity_type
-    geo = payment.geo_region
-    base = payment.net_amount  # net_amount already in EUR (taxable base, not gross)
-
-    treatment = vat_treatment(activity, geo, config)
-    oss_country: Optional[str] = None
-    cc = (payment.card_country or "").upper()
-
-    if treatment == "OSS_EU":
-        # Use card_country for OSS country assignment (only when it has a known rate)
-        oss_country = cc if cc in OSS_RATES else None
-
-    vat_amount = vat_amount_on_base(base, treatment, cc)
-
-    return payment.model_copy(update={
-        "vat_treatment": treatment,
-        "vat_base_eur": round(base, 2),
-        "vat_amount_eur": vat_amount,
-        "oss_country": oss_country,
-    })
-
-
-def classify_payment_with_vat(
-    payment: "Payment",
-    rules: Optional[dict] = None,
-    config: Optional[dict] = None,
-) -> ClassifiedPayment:
-    """Classify activity + geography, then add VAT treatment in one call."""
-    classified = classify_payment(payment, rules)
-    return classify_vat(classified, config)
-
-
 def validate_classifications(payments: list[ClassifiedPayment]) -> dict:
     """Validate indicator sums and return a report dict."""
     activity_errors = [

--- a/src/database.py
+++ b/src/database.py
@@ -1271,24 +1271,3 @@ def load_audit_entries(
         return [dict(r) for r in rows]
     finally:
         conn.close()
-
-
-def upsert_vat_treatment(payment_id: str, vat_treatment: str,
-                         vat_base_eur: float, vat_amount_eur: float,
-                         oss_country: Optional[str] = None,
-                         buyer_vat_id: Optional[str] = None,
-                         db_path: Optional[str | Path] = None) -> None:
-    """Write VAT treatment fields back to the transactions table."""
-    conn = _get_connection(db_path)
-    try:
-        conn.execute(
-            """UPDATE transactions SET
-                   vat_treatment = ?, vat_base_eur = ?, vat_amount_eur = ?,
-                   oss_country = ?, buyer_vat_id = ?, updated_at = datetime('now')
-               WHERE id = ?""",
-            (vat_treatment, vat_base_eur, vat_amount_eur,
-             oss_country, buyer_vat_id, payment_id),
-        )
-        conn.commit()
-    finally:
-        conn.close()

--- a/src/models.py
+++ b/src/models.py
@@ -64,7 +64,8 @@ class ClassifiedPayment(Payment):
     classification_rule: str = ""
     geo_rule: str = ""
 
-    # VAT treatment fields (populated by classify_vat)
+    # VAT treatment fields — derived lazily by the tax engine (src.vat_rules),
+    # not populated on the live classification path; kept for ad-hoc use.
     vat_treatment: Optional[str] = None   # IVA_ES_21 | IVA_EU_B2B | OSS_EU | IVA_EXPORT | …
     vat_base_eur: Optional[float] = None  # taxable base (= net_amount for income, already EUR)
     vat_amount_eur: Optional[float] = None  # IVA collected

--- a/src/tax_engine.py
+++ b/src/tax_engine.py
@@ -7,7 +7,6 @@ from datetime import date, datetime
 from typing import Optional
 
 from src.logger import get_logger
-from src.models import ClassifiedPayment
 from src.tax_models import (
     AuditEntry,
     Modelo130Result,
@@ -19,7 +18,6 @@ from src.tax_models import (
     OSSCountryRow,
     OSSReturnResult,
     TaxDeadline,
-    VATTreatment,
     _tax_deadline_date,
 )
 from src.vat_rules import (
@@ -32,22 +30,6 @@ from src.vat_rules import (
 log = get_logger(__name__)
 
 _DUE_SOON_DAYS = 15
-
-
-# ---------------------------------------------------------------------------
-# VAT treatment helpers
-# ---------------------------------------------------------------------------
-
-def compute_vat_treatment(payment: ClassifiedPayment, config: dict) -> VATTreatment:
-    """Compute VAT treatment for a single payment."""
-    from src.classifier import classify_vat
-    updated = classify_vat(payment, config)
-    return VATTreatment(
-        treatment=updated.vat_treatment or "UNKNOWN",
-        vat_base_eur=updated.vat_base_eur or 0.0,
-        vat_amount_eur=updated.vat_amount_eur or 0.0,
-        oss_country=updated.oss_country,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/tax_models.py
+++ b/src/tax_models.py
@@ -7,10 +7,6 @@ from datetime import date
 from typing import Any, Literal, Optional
 
 
-VATTreatmentType = Literal[
-    "IVA_ES_21", "IVA_EU_B2B", "IVA_EU_B2C", "OSS_EU", "IVA_EXPORT", "EXEMPT", "UNKNOWN"
-]
-
 FilingStatus = Literal["PENDING", "DUE", "OVERDUE", "FILED"]
 
 TaxModel = Literal["303", "390", "130", "100", "347", "349", "OSS"]
@@ -43,14 +39,6 @@ def _tax_deadline_date(model: str, year: int, quarter: int) -> date:
     if model == "347":
         return date(year + 1, 2, 28)
     return date(year, 12, 31)
-
-
-@dataclass
-class VATTreatment:
-    treatment: VATTreatmentType
-    vat_base_eur: float
-    vat_amount_eur: float
-    oss_country: Optional[str] = None
 
 
 @dataclass

--- a/src/vat_rules.py
+++ b/src/vat_rules.py
@@ -1,11 +1,11 @@
 """Single source of truth for the VAT treatment decision matrix and rates.
 
 The activity × geography → ``vat_treatment`` matrix, the OSS rate lookup, and
-the VAT-inclusive base extraction were previously implemented twice — once on
-the Pydantic model in :func:`src.classifier.classify_vat`, and again as a
-fallback in ``src.tax_engine._get_vat_treatment`` / ``_get_vat_base`` /
-``_get_vat_amount``. Divergence between the two copies would produce inconsistent
-figures between what gets stored on a transaction and what the engine recomputes.
+the VAT-inclusive base extraction live here once and are consumed by
+``src.tax_engine._get_vat_treatment`` / ``_get_vat_base`` / ``_get_vat_amount``,
+which derive each transaction's figures lazily from this matrix. Keeping the
+rules in a single module prevents the divergence that a second, parallel copy
+would reintroduce.
 
 This module holds the rules once. It depends only on ``src.tax_models`` (for the
 OSS rate table) so it can be imported from both the classifier and the tax engine

--- a/tests/test_tax_engine.py
+++ b/tests/test_tax_engine.py
@@ -2,18 +2,15 @@
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime
 
 import pytest
 
-from src.classifier import classify_vat
 from src.database import (
     TAX_SNAPSHOT_QUARTER_ANNUAL,
     _get_connection,
     init_db,
     load_tax_snapshots_for_period,
 )
-from src.models import ClassifiedPayment
 from src.tax_engine import (
     compute_and_persist_tax_snapshots,
     compute_modelo_130,
@@ -28,22 +25,6 @@ from src.tax_snapshot_codec import decode_snapshot
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def _make_cp(**kwargs) -> ClassifiedPayment:
-    defaults = dict(
-        id="test_01",
-        created_date=datetime(2025, 1, 15),
-        converted_amount=100.0,
-        converted_amount_refunded=0.0,
-        description="test",
-        fee=0.0,
-        currency="eur",
-        activity_type="COACHING",
-        geo_region="SPAIN",
-    )
-    defaults.update(kwargs)
-    return ClassifiedPayment(**defaults)
-
 
 def _insert_tx(conn: sqlite3.Connection, **kwargs) -> None:
     """Insert a minimal transaction row for tax engine tests."""
@@ -86,45 +67,6 @@ def db_conn(tmp_path):
     conn.row_factory = sqlite3.Row
     yield conn
     conn.close()
-
-
-# ---------------------------------------------------------------------------
-# VAT treatment classification tests
-# ---------------------------------------------------------------------------
-
-class TestClassifyVat:
-    def test_newsletter_eu_not_spain_is_oss(self):
-        cp = _make_cp(activity_type="NEWSLETTER", geo_region="EU_NOT_SPAIN", card_country="DE")
-        result = classify_vat(cp)
-        assert result.vat_treatment == "OSS_EU"
-        assert result.oss_country == "DE"
-        assert result.vat_amount_eur == pytest.approx(100.0 * 0.19, abs=0.01)
-
-    def test_coaching_eu_not_spain_is_b2b(self):
-        cp = _make_cp(activity_type="COACHING", geo_region="EU_NOT_SPAIN")
-        result = classify_vat(cp)
-        assert result.vat_treatment == "IVA_EU_B2B"
-        assert result.vat_amount_eur == 0.0
-
-    def test_any_outside_eu_is_export(self):
-        for activity in ("COACHING", "NEWSLETTER", "ILLUSTRATIONS"):
-            cp = _make_cp(activity_type=activity, geo_region="OUTSIDE_EU")
-            result = classify_vat(cp)
-            assert result.vat_treatment == "IVA_EXPORT"
-            assert result.vat_amount_eur == 0.0
-
-    def test_spain_is_iva_21(self):
-        cp = _make_cp(activity_type="COACHING", geo_region="SPAIN")
-        result = classify_vat(cp)
-        assert result.vat_treatment == "IVA_ES_21"
-        assert result.vat_amount_eur == pytest.approx(21.0, abs=0.01)
-
-    def test_oss_fallback_rate_for_unknown_country(self):
-        cp = _make_cp(activity_type="NEWSLETTER", geo_region="EU_NOT_SPAIN", card_country="XX")
-        result = classify_vat(cp)
-        assert result.vat_treatment == "OSS_EU"
-        # DEFAULT_EU = 21%
-        assert result.vat_amount_eur == pytest.approx(100.0 * 0.21, abs=0.01)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Deleted the never-wired `classify_payment_with_vat` + `classify_vat` feature from `src/classifier.py`, `src/database.py`, `src/tax_engine.py`, `src/tax_models.py`; cleaned stale doc/comment refs in `src/models.py` and `src/vat_rules.py`; removed dead-path `TestClassifyVat` test class
- Eliminates a latent landmine: the dead `classify_vat` treated net as the ex-VAT base, contradicting the live `vat_base_from_inclusive` path — a future wiring attempt would have silently produced wrong numbers
- All deleted symbols were grep-proven dead (never called from live pipeline)

## Test plan

- [x] 83 tests pass (`pytest -q`)
- [x] Modelo 303 box_01_base / box_03_cuota numbers unchanged (12 Modelo 303/130/349 tests all pass)
- [x] Test count drop from 88 → 83 accounts for exactly the 5 removed dead-path tests

Closes #35