### PR TITLE
docs: fix stale CSV-mode and legacy-gemini references in onboarding docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Stripe secret key (required only for live API mode; not needed for CSV-only use)
+# Stripe secret key (required)
 # Restricted keys (rk_live_...): https://dashboard.stripe.com/apikeys — enable "Read charges"
 #   (Stripe internal name: rak_charge_read). Without it, Charge.list fails.
 STRIPE_API_KEY=sk_live_...

--- a/README.md
+++ b/README.md
@@ -570,9 +570,13 @@ All fields required for AEAT compliance (Libro de IVA, SII, Modelo 303/347/349):
 - **Row-selection checkboxes** — select one or more records and click **Delete selected**.
 - **Clear invoice table** — wipes all records (with confirmation); PDF files are never touched.
 
-### Google API key (AI Studio — recommended)
+### Hub provider (default — no Google key needed)
 
-The simplest option: get a free key from [aistudio.google.com/apikey](https://aistudio.google.com/apikey) and add it to `.env`:
+The default `hub` provider routes all PDF extraction through local-llm-hub and needs no Google API key. If `invoice_ocr.provider` is unset (or set to `hub` in `config.json`), no further credential setup is required — stop here.
+
+### Google API key (legacy `gemini` provider)
+
+Only needed if you explicitly set `invoice_ocr.provider` to `gemini` (or `INVOICE_OCR_PROVIDER=gemini`). Get a free key from [aistudio.google.com/apikey](https://aistudio.google.com/apikey) and add it to `.env`:
 
 ```
 GOOGLE_API_KEY=AIzaSy...

--- a/config.json.example
+++ b/config.json.example
@@ -8,7 +8,6 @@
     "historical_start": "2023-07-01",
     "data_dir": "data",
     "logs_dir": "logs",
-    "input_mode": "stripe_api",
     "invoice_in_dir": "data/invoices/in",
     "invoice_out_dir": "data/invoices/out"
   },


### PR DESCRIPTION
## Summary

- `.env.example`: dropped stale "not needed for CSV-only use" clause — the CSV ingest path was removed; `STRIPE_API_KEY` is now unconditionally required.
- `config.json.example`: removed the unused `input_mode: stripe_api` key — no code path reads it from config; all live call-sites hard-code the value directly.
- `README.md`: renamed `### Google API key (AI Studio — recommended)` to `### Google API key (legacy gemini provider)` and added a `### Hub provider (default — no Google key needed)` callout above it, so new readers see the hub path (no Google key required) as the headline before encountering the legacy credential sections.

## Validation

- `config.json.example` JSON validity: `python -c "import json; json.load(open('config.json.example'))"` → valid
- Full test suite: `pytest tests/ -q` → 83 passed, 0 failures, 0 skips
- Diff confined to the three doc files; no Python source, no tests, no dependency changes

CI not awaited — no `.github/workflows/` exists in this repo.

Closes #44