### PR TITLE
fix: diff badge sign before euro symbol so highlight_diff colours fire correctly

### DIFF
--- a/app/tax_validation.py
+++ b/app/tax_validation.py
@@ -53,8 +53,7 @@ def _diff_badge(line: ValidationLine) -> str:
     d = line.diff
     if d is None:
         return "—"
-    sign = "+" if d >= 0 else ""
-    return f"{sign}€{d:,.2f}"
+    return f"{'+' if d >= 0 else '-'}€{abs(d):,.2f}"
 
 
 def _lines_to_df(lines: list[ValidationLine]) -> pd.DataFrame:


### PR DESCRIPTION
## Summary

- `_diff_badge` was building `"€-5.00"` for negative diffs instead of `"-€5.00"` — the `€` sat before the minus sign that `f"{d:,.2f}"` prepended.
- `highlight_diff`'s `val.startswith("-€")` check (the DB_LOW / red branch) therefore never fired for negative diffs.
- Worse, the first branch `val.startswith("€") and not val.startswith("-")` matched `"€-5.00"` (starts with `€`, doesn't start with `-`), so every negative diff was coloured **DB_HIGH (orange)** — exactly backwards.
- Fix: one-line change in `_diff_badge` to use `abs(d)` with an explicit sign prefix, so the sign sits outside the `€` and `startswith("-€")` fires correctly.

## Validation

- `py_compile app/tax_validation.py` → SYNTAX OK
- `pytest tests/` → 83 passed, 0 failed, 0 skipped in 1.55 s
- Behavioural probe: confirmed OLD `-5.0` → `"€-5.00"` → DB_HIGH (wrong); NEW `-5.0` → `"-€5.00"` → DB_LOW (correct)

Closes #43