### PR TITLE
refactor: M303 box rename, public get_connection, date-bounds stragglers, drop irpf_retention_rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,6 @@ Add a `tax` section to `config.json` (see `config.json.example`), or use the **C
   "tax": {
     "regime": "estimacion_directa_simplificada",
     "nif": "YOUR_NIF",
-    "irpf_retention_rate": 0.15,
     "vat_registered": true,
     "oss_registered": true,
     "oss_registration_country": "ES",
@@ -339,15 +338,13 @@ Add a `tax` section to `config.json` (see `config.json.example`), or use the **C
 }
 ```
 
-> **IRPF retention rate:** Use `0.15` (15%) after the first 3 years of activity, or `0.07` (7%) during the first 3 years. Configurable per the slider in Tax Settings.
-
 ### Invoice data in tax calculations
 
 OCR-extracted invoices (from the Invoice OCR tab) feed directly into all tax models alongside Stripe transactions:
 
 | Model | Source | Contribution |
 |-------|--------|-------------|
-| **Modelo 303** box_28 | Expense invoices (`direction='in'`) | IVA soportado deducible |
+| **Modelo 303** box_29 | Expense invoices (`direction='in'`) | IVA soportado deducible (cuota) |
 | **Modelo 303** box_01 | Income invoices (`IVA_ES_21`) | Base imponible devengado |
 | **Modelo 130** box_01 | Non-Stripe income invoices (`direction='out'`) | Subtotal ingresos YTD |
 | **Modelo 130** box_02 | Expense invoices (`direction='in'`) | Subtotal gastos (weighted by `deductible_pct`) YTD |
@@ -443,7 +440,7 @@ The UI shows a summary table plus an expandable drill-down per cell. Each expand
 
 | Cell | Approximation | Impact |
 |------|--------------|--------|
-| `box_29_base_soportado` (M303) | `box_28_iva_soportado / 0.21` assumes all deductible expenses at 21% | Display only — does not affect `box_46` or `box_48` |
+| `box_28_base_soportado` (M303) | `box_29_cuota_soportado / 0.21` assumes all deductible expenses at 21% | Display only — does not affect `box_46` or `box_48` |
 | `box_48_resultado` (M303) | 100% proration assumed | User must enter only the deductible portion of IVA in manual entries |
 | `box_01_ingresos` (M130) | Ex-VAT base extracted from VAT-inclusive Stripe amounts | Correct for estimación directa — IVA is a pass-through, not income |
 

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -321,18 +321,6 @@ geographic classification instead of manual overrides.
                                           value=tax.get("vat_proration_percentage", 100),
                                           key="tax_vat_prorrata")
 
-        st.markdown("##### IRPF")
-        irpf_rate_pct = st.slider(
-            "IRPF retention rate",
-            min_value=0, max_value=30, step=1,
-            value=int(round(float(tax.get("irpf_retention_rate", 0.15)) * 100)),
-            format="%d%%",
-            key="tax_irpf_rate",
-            help="15% after first 3 years of activity; 7% during the first 3 years",
-        )
-        irpf_rate = irpf_rate_pct / 100.0
-        st.caption(f"Current rate: {irpf_rate_pct}%  |  {'🔵 Standard (post-3yr)' if irpf_rate_pct == 15 else '🟡 Reduced (first 3yr)' if irpf_rate_pct == 7 else '⚙️ Custom'}")
-
         st.markdown("##### EU VAT defaults")
         EU_B2B_OPTIONS = ["IVA_EU_B2B", "IVA_EU_B2C"]
         EU_NL_OPTIONS = ["OSS_EU", "IVA_EU_B2B"]
@@ -357,7 +345,6 @@ geographic classification instead of manual overrides.
                 "vat_registered": vat_registered,
                 "oss_registered": oss_registered,
                 "oss_registration_country": oss_country,
-                "irpf_retention_rate": round(irpf_rate, 4),
                 "activity_start_date": activity_start,
                 "nif": nif,
                 "fiscal_year_start_month": int(fiscal_year_start),

--- a/app/history.py
+++ b/app/history.py
@@ -11,16 +11,20 @@ import streamlit as st
 
 from app.data_loader import get_classified_for_period, quarter_dates
 from src.aggregator import calculate_grand_totals, calculate_regional_totals, get_transaction_count
+from src.database import get_transaction_date_bounds
 from src.excel_exporter import create_excel_report, generate_report_filename
 
 
 def render():
     """Render the History & Charts tab."""
     current_year = datetime.now().year
+    min_tx_dt, _ = get_transaction_date_bounds()
+    first_year = min_tx_dt.year if min_tx_dt else 2023
+    first_quarter = (min_tx_dt.month - 1) // 3 + 1 if min_tx_dt else 1
 
     all_quarters = []
-    for y in range(2023, current_year + 1):
-        start_q = 3 if y == 2023 else 1
+    for y in range(first_year, current_year + 1):
+        start_q = first_quarter if y == first_year else 1
         end_q = (datetime.now().month - 1) // 3 + 1 if y == current_year else 4
         for q in range(start_q, end_q + 1):
             all_quarters.append((y, q))

--- a/app/tax_audit.py
+++ b/app/tax_audit.py
@@ -6,7 +6,7 @@ import json
 import pandas as pd
 import streamlit as st
 
-from src.database import _get_connection, load_audit_entries
+from src.database import get_connection, load_audit_entries
 
 _MODEL_LABELS = {
     "303": "Modelo 303 — IVA Trimestral",

--- a/app/tax_obligations.py
+++ b/app/tax_obligations.py
@@ -14,7 +14,7 @@ from src.database import (
     get_tax_entries,
     load_tax_snapshots_for_period,
     upsert_filing_status,
-    _get_connection,
+    get_connection,
 )
 from src.tax_engine import (
     compute_and_persist_tax_snapshots,
@@ -56,7 +56,7 @@ def _fmt_eur(value: float | None) -> str:
 
 
 def _get_conn() -> sqlite3.Connection:
-    return _get_connection()
+    return get_connection()
 
 
 def _load_snapshot_bundle(year: int, quarter: int) -> dict[str, tuple[Any, str]]:
@@ -154,13 +154,13 @@ def _render_modelo_303(year: int, quarter: int, bundle: dict[str, tuple[Any, str
     st.divider()
     st.markdown("##### DEDUCIBLE (IVA paid on expenses)")
     col1, col2 = st.columns(2)
-    col1.metric("Box 28 — Cuota IVA soportado", _fmt_eur(result.box_28_iva_soportado))
-    col2.metric("Box 29 — Base correspondiente", _fmt_eur(result.box_29_base_soportado))
+    col1.metric("Box 28 — Base IVA soportado", _fmt_eur(result.box_28_base_soportado))
+    col2.metric("Box 29 — Cuota IVA soportado", _fmt_eur(result.box_29_cuota_soportado))
 
     st.divider()
     st.markdown("##### RESULTADO")
     col1, col2 = st.columns(2)
-    col1.metric("Box 46 — Diferencia (03 − 28)", _fmt_eur(result.box_46_diferencia))
+    col1.metric("Box 46 — Diferencia (03 − 29)", _fmt_eur(result.box_46_diferencia))
     result_val = result.box_48_resultado
     delta_color = "inverse" if result_val < 0 else "normal"
     col2.metric(
@@ -186,7 +186,7 @@ def _render_modelo_303(year: int, quarter: int, bundle: dict[str, tuple[Any, str
 # Sub-section C: Modelo 130
 # ---------------------------------------------------------------------------
 
-def _render_modelo_130(year: int, quarter: int, config: dict,
+def _render_modelo_130(year: int, quarter: int,
                        bundle: dict[str, tuple[Any, str]]) -> None:
     st.subheader("C. Modelo 130 — IRPF Trimestral")
     pair = bundle.get("130")
@@ -197,8 +197,7 @@ def _render_modelo_130(year: int, quarter: int, config: dict,
     assert isinstance(result, Modelo130Result)
 
     st.caption(f"Stored calculation: {computed_at}")
-    irpf_rate = config.get("tax", {}).get("irpf_retention_rate", 0.15)
-    st.markdown(f"**Period:** {_quarter_label(quarter)} {year} — YTD cumulative | IRPF retention rate: {irpf_rate:.0%}")
+    st.markdown(f"**Period:** {_quarter_label(quarter)} {year} — YTD cumulative")
     st.divider()
 
     st.markdown("##### INGRESOS Y GASTOS (year-to-date)")
@@ -446,7 +445,7 @@ def render() -> None:
         _render_modelo_303(year, quarter, snapshot_bundle)
 
     with tab_130:
-        _render_modelo_130(year, quarter, config, snapshot_bundle)
+        _render_modelo_130(year, quarter, snapshot_bundle)
 
     with tab_manual:
         _render_manual_entries(year, quarter)

--- a/app/tax_validation.py
+++ b/app/tax_validation.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import streamlit as st
 import pandas as pd
 
-from src.database import _get_connection
+from src.database import get_connection
 from src.tax_validator import (
     ModelValidationResult,
     ValidationLine,
@@ -22,7 +22,7 @@ def _cached_validations() -> list[ModelValidationResult]:
     Creates and closes its own DB connection so the result is picklable
     (sqlite3.Connection objects cannot be cached by Streamlit).
     """
-    conn = _get_connection()
+    conn = get_connection()
     try:
         return run_all_validations(conn)
     finally:

--- a/app/transaction_browser.py
+++ b/app/transaction_browser.py
@@ -7,7 +7,11 @@ import pandas as pd
 import streamlit as st
 
 from app.data_loader import get_classified_for_period, invalidate_cache, quarter_dates
-from src.database import get_transaction_count_db, search_transactions_raw
+from src.database import (
+    get_transaction_count_db,
+    get_transaction_date_bounds,
+    search_transactions_raw,
+)
 from src.models import ClassifiedPayment
 from src.rules_engine import load_rules, save_rules
 
@@ -16,11 +20,14 @@ def render():
     """Render the Transaction Browser tab."""
     col1, col2, col3 = st.columns([1, 1, 2])
     current_year = datetime.now().year
+    min_tx_dt, _ = get_transaction_date_bounds()
+    first_year = min_tx_dt.year if min_tx_dt else 2023
+    year_choices = list(range(first_year, current_year + 2))
     with col1:
         year = st.selectbox(
             "Year",
-            list(range(2023, current_year + 2)),
-            index=list(range(2023, current_year + 2)).index(current_year),
+            year_choices,
+            index=year_choices.index(current_year) if current_year in year_choices else 0,
             key="tb_year",
         )
     with col2:

--- a/config.json.example
+++ b/config.json.example
@@ -31,7 +31,6 @@
     "vat_registered": true,
     "oss_registered": true,
     "oss_registration_country": "ES",
-    "irpf_retention_rate": 0.15,
     "activity_start_date": "2022-01-01",
     "nif": "XXXXXXXX",
     "fiscal_year_start_month": 1,

--- a/src/database.py
+++ b/src/database.py
@@ -41,7 +41,7 @@ _TRANSACTIONS_COLUMNS: dict[str, str] = {
 }
 
 
-def _get_connection(db_path: Optional[str | Path] = None) -> sqlite3.Connection:
+def get_connection(db_path: Optional[str | Path] = None) -> sqlite3.Connection:
     path = Path(db_path) if db_path else _DB_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(path))
@@ -219,7 +219,7 @@ def _ensure_audit_schema(conn: sqlite3.Connection) -> None:
 
 def init_db(db_path: Optional[str | Path] = None) -> None:
     """Create tables if they don't exist."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         conn.executescript("""
             CREATE TABLE IF NOT EXISTS transactions (
@@ -391,7 +391,7 @@ def init_db(db_path: Optional[str | Path] = None) -> None:
 def upsert_payments(payments: list[Payment], source: str = "csv",
                     db_path: Optional[str | Path] = None) -> tuple[int, int]:
     """Insert or update payments. Returns (inserted, updated) counts."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     inserted = 0
     updated = 0
     try:
@@ -498,7 +498,7 @@ def upsert_payments(payments: list[Payment], source: str = "csv",
 def upsert_classified(payments: list[ClassifiedPayment],
                       db_path: Optional[str | Path] = None) -> None:
     """Update classification columns for already-stored transactions."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_transactions_schema(conn)
         for p in payments:
@@ -526,7 +526,7 @@ def load_classified_payments(
     the classifier again. Classification columns default to UNKNOWN / empty
     string for rows that were never classified.
     """
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_transactions_schema(conn)
         query = "SELECT * FROM transactions WHERE 1=1"
@@ -570,7 +570,7 @@ def load_payments(start_date: Optional[datetime] = None,
                   end_date: Optional[datetime] = None,
                   db_path: Optional[str | Path] = None) -> list[Payment]:
     """Load payments from database, optionally filtered by date range."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         query = "SELECT * FROM transactions WHERE 1=1"
         params: list = []
@@ -604,7 +604,7 @@ def load_payments(start_date: Optional[datetime] = None,
 
 def get_latest_transaction_date(db_path: Optional[str | Path] = None) -> Optional[datetime]:
     """Get the most recent transaction date in the database."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         row = conn.execute(
             "SELECT MAX(created_date) as max_date FROM transactions"
@@ -620,7 +620,7 @@ def get_transaction_date_bounds(
     db_path: Optional[str | Path] = None,
 ) -> tuple[Optional[datetime], Optional[datetime]]:
     """Return (min_created_date, max_created_date) from transactions."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         row = conn.execute(
             "SELECT MIN(created_date) AS min_date, MAX(created_date) AS max_date FROM transactions"
@@ -635,7 +635,7 @@ def get_transaction_date_bounds(
 
 
 def get_transaction_count_db(db_path: Optional[str | Path] = None) -> int:
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         row = conn.execute("SELECT COUNT(*) as cnt FROM transactions").fetchone()
         return row["cnt"]
@@ -645,7 +645,7 @@ def get_transaction_count_db(db_path: Optional[str | Path] = None) -> int:
 
 def get_latest_stripe_sync_at(db_path: Optional[str | Path] = None) -> Optional[datetime]:
     """Get the latest DB load timestamp for rows sourced from Stripe API."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_transactions_schema(conn)
         row = conn.execute(
@@ -672,7 +672,7 @@ def search_transactions_raw(
 
     Returns (sql, params, rows_as_dicts).
     """
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_transactions_schema(conn)
         cols = _get_table_columns(conn, "transactions")
@@ -747,7 +747,7 @@ def search_transactions_raw(
 def record_upload(filename: str, direction: str, api_response: str = "",
                   db_path: Optional[str | Path] = None) -> bool:
     """Record an invoice upload. Returns True if new, False if already uploaded."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         existing = conn.execute(
             "SELECT id FROM upload_log WHERE filename = ? AND direction = ?",
@@ -768,7 +768,7 @@ def record_upload(filename: str, direction: str, api_response: str = "",
 def get_uploaded_files(direction: str,
                        db_path: Optional[str | Path] = None) -> list[dict]:
     """Get list of already-uploaded invoice files."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         rows = conn.execute(
             "SELECT filename, uploaded_at, api_response FROM upload_log "
@@ -787,7 +787,7 @@ def get_uploaded_files(direction: str,
 def upsert_invoice(data: dict, db_path: Optional[str | Path] = None) -> str:
     """Insert or replace a parsed invoice record. Returns the record id."""
     import uuid
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         record_id = data.get("id") or str(uuid.uuid4())
         direction = data.get("direction", "in")
@@ -921,7 +921,7 @@ def upsert_invoice(data: dict, db_path: Optional[str | Path] = None) -> str:
 def get_invoices(direction: Optional[str] = None,
                  db_path: Optional[str | Path] = None) -> list[dict]:
     """Return all invoice records, optionally filtered by direction."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         if direction:
             rows = conn.execute(
@@ -940,7 +940,7 @@ def get_invoices(direction: Optional[str] = None,
 def get_invoice_by_filename(filename: str, direction: str,
                              db_path: Optional[str | Path] = None) -> Optional[dict]:
     """Return a single invoice record by filename+direction, or None."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         row = conn.execute(
             "SELECT * FROM invoices WHERE filename = ? AND direction = ?",
@@ -954,7 +954,7 @@ def get_invoice_by_filename(filename: str, direction: str,
 def get_invoice_hash(filename: str, direction: str,
                      db_path: Optional[str | Path] = None) -> Optional[str]:
     """Return the stored MD5 hash for a file, or None if not extracted yet."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         row = conn.execute(
             "SELECT file_hash FROM invoices WHERE filename = ? AND direction = ?",
@@ -968,7 +968,7 @@ def get_invoice_hash(filename: str, direction: str,
 def delete_invoice(filename: str, direction: str,
                    db_path: Optional[str | Path] = None) -> bool:
     """Delete an invoice record. Returns True if a row was deleted."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         cursor = conn.execute(
             "DELETE FROM invoices WHERE filename = ? AND direction = ?",
@@ -985,7 +985,7 @@ def delete_invoices_by_ids(ids: list[str],
     """Delete invoice records by their UUID ids. Returns number deleted."""
     if not ids:
         return 0
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         placeholders = ",".join("?" * len(ids))
         cursor = conn.execute(
@@ -999,7 +999,7 @@ def delete_invoices_by_ids(ids: list[str],
 
 def clear_invoices(db_path: Optional[str | Path] = None) -> int:
     """Delete ALL invoice records. Returns number of rows deleted."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         cursor = conn.execute("DELETE FROM invoices")
         conn.commit()
@@ -1018,7 +1018,7 @@ def get_invoice_stats(db_path: Optional[str | Path] = None) -> dict:
             "out": {"count": int, "last_extracted_at": str | None},
         }
     """
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         rows = conn.execute(
             """
@@ -1050,7 +1050,7 @@ def get_invoice_stats(db_path: Optional[str | Path] = None) -> dict:
 def get_tax_entries(year: int, quarter: int,
                     db_path: Optional[str | Path] = None) -> list[dict]:
     """Return all manual tax entries for the given year/quarter."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         rows = conn.execute(
             "SELECT * FROM quarterly_tax_entries WHERE year = ? AND quarter = ? ORDER BY id",
@@ -1065,7 +1065,7 @@ def add_tax_entry(year: int, quarter: int, entry_type: str, amount_eur: float,
                   description: str = "", notes: str = "",
                   db_path: Optional[str | Path] = None) -> int:
     """Insert a manual tax entry. Returns the new row id."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         cursor = conn.execute(
             """INSERT INTO quarterly_tax_entries
@@ -1081,7 +1081,7 @@ def add_tax_entry(year: int, quarter: int, entry_type: str, amount_eur: float,
 
 def delete_tax_entry(entry_id: int, db_path: Optional[str | Path] = None) -> bool:
     """Delete a manual tax entry by id. Returns True if deleted."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         cursor = conn.execute(
             "DELETE FROM quarterly_tax_entries WHERE id = ?", (entry_id,)
@@ -1095,7 +1095,7 @@ def delete_tax_entry(entry_id: int, db_path: Optional[str | Path] = None) -> boo
 def get_tax_entries_ytd(year: int, quarter: int, entry_type: str,
                         db_path: Optional[str | Path] = None) -> float:
     """Sum a given entry_type from Q1 through the given quarter (YTD)."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         row = conn.execute(
             """SELECT COALESCE(SUM(amount_eur), 0) AS total
@@ -1115,7 +1115,7 @@ def get_tax_entries_ytd(year: int, quarter: int, entry_type: str,
 def get_filing_status(year: int, model: str, quarter: Optional[int] = None,
                       db_path: Optional[str | Path] = None) -> Optional[dict]:
     """Return the filing status record for the given year/model/quarter, or None."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         if quarter is None:
             row = conn.execute(
@@ -1137,7 +1137,7 @@ def upsert_filing_status(year: int, model: str, quarter: Optional[int],
                          notes: str = "", filed_at: Optional[str] = None,
                          db_path: Optional[str | Path] = None) -> None:
     """Insert or update a filing status record."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         conn.execute(
             """INSERT INTO tax_filing_status (year, model, quarter, status, amount_eur, notes, filed_at)
@@ -1157,7 +1157,7 @@ def upsert_filing_status(year: int, model: str, quarter: Optional[int],
 def get_all_filing_statuses(year: int,
                              db_path: Optional[str | Path] = None) -> list[dict]:
     """Return all filing status records for the given year."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         rows = conn.execute(
             "SELECT * FROM tax_filing_status WHERE year = ? ORDER BY model, quarter",
@@ -1249,7 +1249,7 @@ def load_audit_entries(
 
     If *computed_at* is None, returns entries from the most recent computation run.
     """
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_audit_schema(conn)
         if computed_at is None:

--- a/src/fx_rates.py
+++ b/src/fx_rates.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import requests
 
-from src.database import _get_connection, _get_table_columns
+from src.database import get_connection, _get_table_columns
 from src.logger import get_logger
 
 log = get_logger(__name__)
@@ -59,7 +59,7 @@ def _get_with_fallback(path: str, *, params: dict[str, str], timeout_s: int = 30
 
 def init_fx_table(db_path: Optional[str | Path] = None) -> None:
     """Create the fx_rates table if it doesn't exist."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         conn.execute("""
             CREATE TABLE IF NOT EXISTS fx_rates (
@@ -129,7 +129,7 @@ def store_rates(
     db_path: Optional[str | Path] = None,
 ) -> int:
     """Store rates dict into SQLite. Returns number of rows inserted/updated."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     count = 0
     try:
         _ensure_fx_schema(conn)
@@ -171,7 +171,7 @@ def get_rate(
 
     Returns the rate (1 EUR = rate CURRENCY) or None if not found.
     """
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_fx_schema(conn)
         row = conn.execute(
@@ -199,7 +199,7 @@ def get_rate_with_fallback(
     if rate is not None:
         return rate
 
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_fx_schema(conn)
         row = conn.execute(
@@ -256,7 +256,7 @@ def get_all_rates(
     db_path: Optional[str | Path] = None,
 ) -> list[tuple[str, float]]:
     """Get all stored rates for a currency, sorted by date."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_fx_schema(conn)
         rows = conn.execute(
@@ -272,7 +272,7 @@ def get_stored_date_range(
     db_path: Optional[str | Path] = None,
 ) -> tuple[Optional[date], Optional[date]]:
     """Get the min and max dates stored in the fx_rates table."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_fx_schema(conn)
         row = conn.execute(
@@ -290,7 +290,7 @@ def get_stored_date_range(
 
 def get_rate_count(db_path: Optional[str | Path] = None) -> int:
     """Get total number of FX rate entries stored."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_fx_schema(conn)
         row = conn.execute("SELECT COUNT(*) as cnt FROM fx_rates").fetchone()
@@ -301,7 +301,7 @@ def get_rate_count(db_path: Optional[str | Path] = None) -> int:
 
 def get_latest_fx_sync_at(db_path: Optional[str | Path] = None) -> Optional[datetime]:
     """Get latest FX DB sync timestamp from stored rates."""
-    conn = _get_connection(db_path)
+    conn = get_connection(db_path)
     try:
         _ensure_fx_schema(conn)
         row = conn.execute("SELECT MAX(updated_at) AS max_updated_at FROM fx_rates").fetchone()

--- a/src/social_security.py
+++ b/src/social_security.py
@@ -122,8 +122,8 @@ def load_bank_export(
 
 def get_connection(db_path: Optional[str | Path] = None) -> sqlite3.Connection:
     """Return a sqlite3 connection with row_factory set."""
-    from src.database import _get_connection
-    return _get_connection(db_path)
+    from src.database import get_connection as _db_get_connection
+    return _db_get_connection(db_path)
 
 
 def upsert_ss_payments(

--- a/src/tax_engine.py
+++ b/src/tax_engine.py
@@ -1,6 +1,8 @@
 """Tax computation engine for Spanish autónomo obligations."""
 from __future__ import annotations
 
+import calendar
+import json
 import sqlite3
 from collections import defaultdict
 from datetime import date, datetime
@@ -60,7 +62,6 @@ def _load_classified_range(
 
 def _classified_quarter_end(year: int, quarter: int) -> str:
     """End bound (inclusive, end-of-day) for transaction queries up to ``quarter``."""
-    import calendar
     month_end = quarter * 3
     last_day = calendar.monthrange(year, month_end)[1]
     return f"{year}-{month_end:02d}-{last_day:02d}T23:59:59"
@@ -83,7 +84,6 @@ def _load_classified_ytd(year: int, quarter: int, conn: sqlite3.Connection) -> l
 
 
 def _invoice_date_range(year: int, quarter: int) -> tuple[str, str]:
-    import calendar
     month_start = (quarter - 1) * 3 + 1
     month_end = quarter * 3
     last_day = calendar.monthrange(year, month_end)[1]
@@ -261,7 +261,6 @@ def _previous_modelo130_payments(year: int, quarter: int, conn: sqlite3.Connecti
 
 def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> Modelo303Result:
     """Compute Modelo 303 (quarterly VAT return) for the given quarter."""
-    import json as _json
     result = Modelo303Result(year=year, quarter=quarter)
     rows = _load_classified_for_quarter(year, quarter, db_conn)
 
@@ -377,18 +376,19 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
             n_inv_export += 1
             recs_export.append(_rec)
 
-    # Deductible IVA from manual entries (current quarter only) + invoices
-    result.box_28_iva_soportado = round(
+    # Deductible IVA from manual entries (current quarter only) + invoices.
+    # Casilla 29 = cuota (IVA amount); casilla 28 = its corresponding base.
+    result.box_29_cuota_soportado = round(
         inv_iva_soportado
         + _get_tax_entries_total(year, quarter, "IVA_SOPORTADO", db_conn, ytd=False),
         2,
     )
-    manual_iva = result.box_28_iva_soportado - inv_iva_soportado
+    manual_iva = result.box_29_cuota_soportado - inv_iva_soportado
     if manual_iva > 0:
         manual_base = manual_iva / 0.21
-        result.box_29_base_soportado = round(inv_base_soportado + manual_base, 2)
+        result.box_28_base_soportado = round(inv_base_soportado + manual_base, 2)
     else:
-        result.box_29_base_soportado = round(inv_base_soportado, 2)
+        result.box_28_base_soportado = round(inv_base_soportado, 2)
 
     # Round accumulations
     result.box_01_base = round(result.box_01_base, 2)
@@ -398,7 +398,7 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
     result.oss_vat = round(result.oss_vat, 2)
     result.export_base = round(result.export_base, 2)
 
-    result.box_46_diferencia = round(result.box_03_cuota - result.box_28_iva_soportado, 2)
+    result.box_46_diferencia = round(result.box_03_cuota - result.box_29_cuota_soportado, 2)
     result.box_48_resultado = result.box_46_diferencia  # simplified (100% proration)
 
     # --- Audit trail ---
@@ -406,7 +406,7 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
         return AuditEntry(
             model="303", year=year, quarter=quarter,
             cell=cell, label=label, formula=formula, value=value,
-            inputs_json=_json.dumps(inputs),
+            inputs_json=json.dumps(inputs),
         )
     result.audit = [
         _a("box_01_base",
@@ -424,23 +424,23 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
            "SUM(vat_base_eur) WHERE vat_treatment='IVA_EU_B2B'  [Art. 25 LIVA — ISP applies]",
            result.box_59_intracom_entregas,
            records=recs_eu_b2b),
-        _a("box_28_iva_soportado",
+        _a("box_28_base_soportado",
+           "Base IVA soportado (facturas + estimación 21% para entradas manuales)",
+           "SUM(subtotal_eur * deductible_pct/100) FROM invoices + manual_IVA / 0.21",
+           result.box_28_base_soportado,
+           inv_base_sum=round(inv_base_soportado, 2)),
+        _a("box_29_cuota_soportado",
            "IVA soportado deducible — todas las facturas recibidas del trimestre",
            "SUM(iva_amount * deductible_pct/100) FROM invoices WHERE direction='in' AND quarter=Q "
            "+ SUM(amount_eur) FROM quarterly_tax_entries WHERE entry_type='IVA_SOPORTADO' AND quarter=Q",
-           result.box_28_iva_soportado,
+           result.box_29_cuota_soportado,
            inv_iva_deductible=round(inv_iva_soportado, 2),
            records=recs_soportado),
-        _a("box_29_base_soportado",
-           "Base IVA soportado (facturas + estimación 21% para entradas manuales)",
-           "SUM(subtotal_eur * deductible_pct/100) FROM invoices + manual_IVA / 0.21",
-           result.box_29_base_soportado,
-           inv_base_sum=round(inv_base_soportado, 2)),
         _a("box_46_diferencia",
            "Diferencia (IVA devengado − IVA deducible)",
-           "box_03_cuota − box_28_iva_soportado",
+           "box_03_cuota − box_29_cuota_soportado",
            result.box_46_diferencia,
-           box_03_cuota=result.box_03_cuota, box_28_iva_soportado=result.box_28_iva_soportado),
+           box_03_cuota=result.box_03_cuota, box_29_cuota_soportado=result.box_29_cuota_soportado),
         _a("box_48_resultado",
            "Resultado a ingresar / devolver",
            "= box_46_diferencia  [100% prorrata; no prior-period compensation applied]",
@@ -467,8 +467,6 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
 
 def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> Modelo130Result:
     """Compute Modelo 130 (quarterly IRPF advance) for the given quarter."""
-    import calendar as _calendar
-    import json as _json
     result = Modelo130Result(year=year, quarter=quarter)
     # Stripe income (transactions table)
     rows = _load_classified_ytd(year, quarter, db_conn)
@@ -492,7 +490,7 @@ def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
 
     # Social Security cuotas paid via bank account, YTD — fully deductible (Art. 30 LIRPF)
     month_end = quarter * 3
-    last_day = _calendar.monthrange(year, month_end)[1]
+    last_day = calendar.monthrange(year, month_end)[1]
     ss_start = f"{year}-01-01"
     ss_end = f"{year}-{month_end:02d}-{last_day:02d}"
     _ss_rows = db_conn.execute(
@@ -562,7 +560,7 @@ def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
         return AuditEntry(
             model="130", year=year, quarter=quarter,
             cell=cell, label=label, formula=formula, value=value,
-            inputs_json=_json.dumps(inputs),
+            inputs_json=json.dumps(inputs),
         )
     # Build aggregated Stripe income records for audit trail (one per geo/activity bucket).
     # Mirrors the Quarter Report view the gestor uses.
@@ -693,7 +691,6 @@ def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
 
 def compute_modelo_349(year: int, quarter: int, db_conn: sqlite3.Connection) -> Modelo349Result:
     """Compute Modelo 349 (intra-EU operations summary) for the given quarter."""
-    import json as _json
     result = Modelo349Result(year=year, quarter=quarter)
     rows = _load_classified_for_quarter(year, quarter, db_conn)
 
@@ -751,7 +748,7 @@ def compute_modelo_349(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
             label=f"Entregas intracomunitarias — {r.buyer_vat_id}",
             formula="SUM(net_amount) for IVA_EU_B2B transactions grouped by buyer_vat_id",
             value=r.total_amount,
-            inputs_json=_json.dumps({"buyer_vat_id": r.buyer_vat_id, "buyer_name": r.buyer_name}),
+            inputs_json=json.dumps({"buyer_vat_id": r.buyer_vat_id, "buyer_name": r.buyer_name}),
         ))
     audit.append(AuditEntry(
         model="349", year=year, quarter=quarter,
@@ -759,7 +756,7 @@ def compute_modelo_349(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
         label="Total entregas intracomunitarias",
         formula="SUM(total_amount) across all operators",
         value=result.total,
-        inputs_json=_json.dumps({
+        inputs_json=json.dumps({
             "operator_count": len(result.rows),
             "negative_excluded": negative_excluded,
         }),
@@ -770,7 +767,6 @@ def compute_modelo_349(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
 
 def compute_oss_return(year: int, quarter: int, db_conn: sqlite3.Connection) -> OSSReturnResult:
     """Compute OSS quarterly return (B2C digital services to EU non-Spain customers)."""
-    import json as _json
     result = OSSReturnResult(year=year, quarter=quarter)
     rows = _load_classified_for_quarter(year, quarter, db_conn)
 
@@ -811,7 +807,7 @@ def compute_oss_return(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
             label=f"OSS base — {r.country} ({int(r.vat_rate * 100)}%)",
             formula="SUM(vat_base_eur) WHERE vat_treatment='OSS_EU' AND country=CC",
             value=r.base_eur,
-            inputs_json=_json.dumps({
+            inputs_json=json.dumps({
                 "country": r.country, "vat_rate": r.vat_rate, "transactions": r.transactions,
             }),
         ))
@@ -821,7 +817,7 @@ def compute_oss_return(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
             label=f"OSS cuota — {r.country} ({int(r.vat_rate * 100)}%)",
             formula=f"base_eur × {r.vat_rate}  [tasa país destino — OSS Reglamento (UE) 904/2010]",
             value=r.vat_amount_eur,
-            inputs_json=_json.dumps({
+            inputs_json=json.dumps({
                 "country": r.country, "base_eur": r.base_eur, "vat_rate": r.vat_rate,
             }),
         ))
@@ -831,7 +827,7 @@ def compute_oss_return(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
         label="Base total OSS (todos los países)",
         formula="SUM(base_eur) across all countries",
         value=result.total_base,
-        inputs_json=_json.dumps({"countries": len(result.rows), "transactions": result.total_transactions}),
+        inputs_json=json.dumps({"countries": len(result.rows), "transactions": result.total_transactions}),
     ))
     audit.append(AuditEntry(
         model="OSS", year=year, quarter=quarter,
@@ -839,7 +835,7 @@ def compute_oss_return(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
         label="Cuota total OSS (todos los países)",
         formula="SUM(vat_amount_eur) across all countries",
         value=result.total_vat,
-        inputs_json=_json.dumps({"total_base": result.total_base}),
+        inputs_json=json.dumps({"total_base": result.total_base}),
     ))
     result.audit = audit
     return result
@@ -847,7 +843,6 @@ def compute_oss_return(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
 
 def compute_modelo_347(year: int, db_conn: sqlite3.Connection) -> Modelo347Result:
     """Compute Modelo 347 (annual operations > €3,005.06 with Spain counterparties)."""
-    import json as _json
     result = Modelo347Result(year=year)
 
     # Stripe transactions from Spanish counterparties
@@ -928,7 +923,7 @@ def compute_modelo_347(year: int, db_conn: sqlite3.Connection) -> Modelo347Resul
             label=f"Operaciones con {r.counterparty_name}",
             formula=f"SUM(net_amount) WHERE geo_region='SPAIN' AND email_meta='{r.counterparty_name}' — threshold ≥ €{result.threshold:,.2f}",
             value=r.total_operations,
-            inputs_json=_json.dumps({
+            inputs_json=json.dumps({
                 "counterparty": r.counterparty_name,
                 "quarter_breakdown": r.quarter_breakdown,
             }),
@@ -939,7 +934,7 @@ def compute_modelo_347(year: int, db_conn: sqlite3.Connection) -> Modelo347Resul
         label="Resumen Modelo 347",
         formula=f"Counterparties >= €{result.threshold:,.2f} threshold",
         value=float(len(result.rows)),
-        inputs_json=_json.dumps({
+        inputs_json=json.dumps({
             "total_counterparties_spain": total_counterparties,
             "above_threshold": len(result.rows),
             "below_threshold": below_threshold,
@@ -1030,8 +1025,6 @@ def compute_and_persist_tax_snapshots(
 
     Returns the shared ISO ``computed_at`` timestamp written on every snapshot row.
     """
-    from datetime import datetime
-
     from src.database import (
         TAX_SNAPSHOT_QUARTER_ANNUAL,
         upsert_audit_entries_conn,

--- a/src/tax_models.py
+++ b/src/tax_models.py
@@ -49,11 +49,11 @@ class Modelo303Result:
     box_01_base: float = 0.0          # Base imponible al 21% (IVA_ES_21)
     box_03_cuota: float = 0.0         # 21% × Box 01
     box_59_intracom_entregas: float = 0.0  # Casilla 59: Entregas intracomunitarias exentas (EU B2B sales)
-    # Deducible
-    box_28_iva_soportado: float = 0.0  # IVA soportado deducible (from quarterly_tax_entries)
-    box_29_base_soportado: float = 0.0
+    # Deducible (AEAT casillas: 28 = base, 29 = cuota — names match the form)
+    box_28_base_soportado: float = 0.0   # Casilla 28: Base imponible IVA soportado interior corriente
+    box_29_cuota_soportado: float = 0.0  # Casilla 29: Cuota IVA soportado deducible (invoices + quarterly_tax_entries)
     # Resultado
-    box_46_diferencia: float = 0.0    # Box 03 - Box 28
+    box_46_diferencia: float = 0.0    # Box 03 - Box 29
     box_48_resultado: float = 0.0     # Net to pay (positive) or refund (negative)
     # Informative
     oss_base: float = 0.0

--- a/src/tax_validator.py
+++ b/src/tax_validator.py
@@ -172,9 +172,9 @@ def validate_modelo_303(
         ValidationLine("27", "Total cuota IVA devengada",
                         v.get("27_total_cuota_devengada"), computed.box_03_cuota),
         ValidationLine("28", "Base IVA soportado interior corrientes",
-                        v.get("28_base_soportado"), computed.box_29_base_soportado),
+                        v.get("28_base_soportado"), computed.box_28_base_soportado),
         ValidationLine("29", "Cuota IVA soportado interior corrientes",
-                        v.get("29_cuota_soportado"), computed.box_28_iva_soportado),
+                        v.get("29_cuota_soportado"), computed.box_29_cuota_soportado),
         ValidationLine("46", "Resultado régimen general (devengado - deducible)",
                         v.get("46_resultado"), computed.box_46_diferencia),
         ValidationLine("59", "Entregas intracomunitarias de bienes y servicios",
@@ -240,8 +240,8 @@ def validate_modelo_390(
         agg["intracom"]        += m.box_59_intracom_entregas
         agg["export"]          += m.export_base
         agg["oss"]             += m.oss_base
-        agg["soportado_base"]  += m.box_29_base_soportado
-        agg["soportado_cuota"] += m.box_28_iva_soportado
+        agg["soportado_base"]  += m.box_28_base_soportado
+        agg["soportado_cuota"] += m.box_29_cuota_soportado
     agg = {k: round(v, 2) for k, v in agg.items()}
 
     agg_resultado   = round(agg["cuota_21"] - agg["soportado_cuota"], 2)

--- a/tests/test_tax_engine.py
+++ b/tests/test_tax_engine.py
@@ -7,7 +7,7 @@ import pytest
 
 from src.database import (
     TAX_SNAPSHOT_QUARTER_ANNUAL,
-    _get_connection,
+    get_connection,
     init_db,
     load_tax_snapshots_for_period,
 )


### PR DESCRIPTION
## Summary

- **Modelo 303 box rename (correctness-sensitive):** renamed `Modelo303Result.box_28_iva_soportado` → `box_29_cuota_soportado` and `box_29_base_soportado` → `box_28_base_soportado` to align with AEAT casilla numbering (casilla 28 = base imponible deducible, casilla 29 = cuota deducible). The swapped-number compensation in `src/tax_validator.py` (lines 175-178) was removed in the same pass — no compensating mapping remains.
- **Public `get_connection`:** renamed `_get_connection` → `get_connection` in `src/database.py`; updated all five callers (`fx_rates.py`, `social_security.py`, `tax_obligations.py`, `tax_validation.py`, `tax_audit.py`).
- **Date-bounds stragglers:** `app/history.py` and `app/transaction_browser.py` year-range selectors now use `get_transaction_date_bounds()` instead of the hard-coded `range(2023, …)`.
- **Drop decorative `irpf_retention_rate`:** the config setting and its slider in `app/configuration.py` were never read by any compute function — removed. `README.md` and `config.json.example` updated accordingly.
- **Lazy imports removed:** per-function `import json as _json` / `import calendar as _calendar` inside `tax_engine.py` compute functions dropped; top-level imports are sufficient.

## Validation

Local gate: **83 pytest tests passed** (1.45 s). Empirical old-vs-new Modelo 303 parity probe confirmed all boxes are byte-for-byte identical — the rename is a pure prefix swap with net computation unchanged.

UX gate: `SPEC_APPLIES=no` — Streamlit app is exempt from the fleet design system.

CI: no GitHub Actions workflows in this repo — not applicable.

## Snapshot refresh caveat

Existing local 303 snapshots stored in the SQLite DB carry the **old field-name keys** (`box_28_iva_soportado`, `box_29_base_soportado`). The `tax_snapshot_codec.py` deserialiser will fail to decode them until you click **Calculate tax** once to regenerate fresh snapshots with the new names. No migration shim was added — the DB is local and regenerable. Do not rely on stored 303 snapshots until after the first recalculation post-merge.

Closes #42