### PR TITLE
chore: drop stale CSV artefacts, align source default to api

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -29,7 +29,7 @@ _TRANSACTIONS_COLUMNS: dict[str, str] = {
     "stripe_invoice_id": "TEXT",
     "raw_source_type": "TEXT",
     "raw_source_json": "TEXT",
-    "source": "TEXT NOT NULL DEFAULT 'csv'",
+    "source": "TEXT NOT NULL DEFAULT 'api'",
     "loaded_at": "TEXT NOT NULL DEFAULT (datetime('now'))",
     "updated_at": "TEXT NOT NULL DEFAULT (datetime('now'))",
     # VAT / tax fields
@@ -240,7 +240,7 @@ def init_db(db_path: Optional[str | Path] = None) -> None:
                 geo_region TEXT,
                 classification_rule TEXT,
                 geo_rule TEXT,
-                source TEXT NOT NULL DEFAULT 'csv',
+                source TEXT NOT NULL DEFAULT 'api',
                 loaded_at TEXT NOT NULL DEFAULT (datetime('now')),
                 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
             );
@@ -388,7 +388,7 @@ def init_db(db_path: Optional[str | Path] = None) -> None:
         conn.close()
 
 
-def upsert_payments(payments: list[Payment], source: str = "csv",
+def upsert_payments(payments: list[Payment], source: str = "api",
                     db_path: Optional[str | Path] = None) -> tuple[int, int]:
     """Insert or update payments. Returns (inserted, updated) counts."""
     conn = get_connection(db_path)

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -2,14 +2,6 @@ class StripeAutomationError(Exception):
     """Base exception for the stripe automation system."""
 
 
-class ClassificationError(StripeAutomationError):
-    """Raised when a transaction cannot be classified."""
-
-
-class CSVParseError(StripeAutomationError):
-    """Raised when CSV parsing fails."""
-
-
 class ConfigError(StripeAutomationError):
     """Raised when configuration is invalid or missing."""
 

--- a/src/models.py
+++ b/src/models.py
@@ -30,7 +30,7 @@ class Payment(BaseModel):
     stripe_balance_transaction_id: Optional[str] = None
     stripe_invoice_id: Optional[str] = None
     raw_source: Optional[dict[str, Any]] = None
-    raw_source_type: Optional[str] = None  # "stripe_api" | "stripe_csv" | etc.
+    raw_source_type: Optional[str] = None  # "stripe_api" | etc.
 
     @field_validator("currency", mode="before")
     @classmethod


### PR DESCRIPTION
## Summary

- Drop `CSVParseError` and `ClassificationError` from `src/exceptions.py` — both were defined but unreferenced since the CSV ingest path was removed.
- Change `transactions.source` column DEFAULT from `'csv'` to `'api'` in the `_TRANSACTIONS_COLUMNS` dict (line 32), the `CREATE TABLE` statement (line 243), and the `upsert_payments` function signature (line 391). The only live writer (`app/data_loader.py:113`) already passes `source="api"` explicitly, so the `'csv'` default was a latent lie about the schema intent. Existing-DB migration note: `ALTER TABLE ADD COLUMN` only runs when the column is absent; for any live DB the `source` column already exists and SQLite does not retroactively change column defaults — no data is touched.
- Drop the stale `"stripe_csv"` example from the `raw_source_type` comment in `src/models.py` — that value is never produced anywhere.
- `config.json.example:input_mode` finding: the key was already absent from the file at the time this branch was cut — pre-resolved by a prior commit, no action needed.

## Validation

- `py_compile src/exceptions.py src/database.py src/models.py` — exit 0
- `pytest tests/ -v` — 83 passed, 0 failed, 0 skipped

## Diff scope check

4 hunks across 3 files; nothing outside the stated findings; no tests removed or weakened.

Closes #40