### PR TITLE
chore: add stable key= to all keyless Streamlit widgets

### DIFF
--- a/app/invoice_explorer.py
+++ b/app/invoice_explorer.py
@@ -55,25 +55,25 @@ def render() -> None:
 
         # Direction
         directions = ["All"] + sorted(df["direction"].dropna().unique().tolist())
-        direction_sel = f1.selectbox("Direction", directions)
+        direction_sel = f1.selectbox("Direction", directions, key="inv_explorer_direction")
 
         # Category
         cats = sorted(df["category"].dropna().unique().tolist()) if "category" in df.columns else []
-        cat_sel = f2.multiselect("Category", cats)
+        cat_sel = f2.multiselect("Category", cats, key="inv_explorer_cat")
 
         # Invoice type
         if "invoice_type" in df.columns:
             types = sorted(df["invoice_type"].dropna().unique().tolist())
-            type_sel = f3.multiselect("Invoice type", types)
+            type_sel = f3.multiselect("Invoice type", types, key="inv_explorer_type")
         else:
             type_sel = []
 
         f4, f5 = st.columns(2)
 
         # Vendor name (free text)
-        vendor_q = f4.text_input("Vendor name contains")
+        vendor_q = f4.text_input("Vendor name contains", key="inv_explorer_vendor")
         # Client name (free text)
-        client_q = f5.text_input("Client name contains")
+        client_q = f5.text_input("Client name contains", key="inv_explorer_client")
 
         f6, f7 = st.columns(2)
 
@@ -82,8 +82,8 @@ def render() -> None:
         max_date = df["invoice_date"].max() if "invoice_date" in df.columns and not df["invoice_date"].isna().all() else None
 
         if min_date is not None and not pd.isna(min_date):
-            date_from = f6.date_input("Invoice date from", value=min_date.date(), min_value=min_date.date(), max_value=max_date.date())
-            date_to = f7.date_input("Invoice date to", value=max_date.date(), min_value=min_date.date(), max_value=max_date.date())
+            date_from = f6.date_input("Invoice date from", value=min_date.date(), min_value=min_date.date(), max_value=max_date.date(), key="inv_explorer_date_from")
+            date_to = f7.date_input("Invoice date to", value=max_date.date(), min_value=min_date.date(), max_value=max_date.date(), key="inv_explorer_date_to")
         else:
             date_from = None
             date_to = None
@@ -100,6 +100,7 @@ def render() -> None:
                     max_value=max_sub,
                     value=(min_sub, max_sub),
                     step=1.0,
+                    key="inv_explorer_subtotal",
                 )
             else:
                 sub_range = None
@@ -107,7 +108,7 @@ def render() -> None:
             sub_range = None
 
         # Rectificativas only
-        show_rect_only = f9.checkbox("Rectificativas only")
+        show_rect_only = f9.checkbox("Rectificativas only", key="inv_explorer_rectificativas")
 
     # ── Apply filters ─────────────────────────────────────────────────────────
     mask = pd.Series([True] * len(df), index=df.index)
@@ -177,4 +178,5 @@ def render() -> None:
         data=csv,
         file_name="invoices_filtered.csv",
         mime="text/csv",
+        key="inv_explorer_download",
     )

--- a/app/social_security_tab.py
+++ b/app/social_security_tab.py
@@ -55,21 +55,23 @@ def render() -> None:
         file_path_str = st.text_input(
             "Bank export file path (.xlsx / .xls / .csv)",
             value=default_file,
+            key="ss_file_path",
             help="Path relative to the project root, or absolute. "
                  "Configure the default in config.json → social_security.bank_export_file",
         )
-        date_column = st.text_input("Date column name", value=default_date_col)
-        amount_column = st.text_input("Amount column name", value=default_amount_col)
+        date_column = st.text_input("Date column name", value=default_date_col, key="ss_date_col")
+        amount_column = st.text_input("Amount column name", value=default_amount_col, key="ss_amount_col")
     with col2:
         description_column = st.text_input(
-            "Description column name (optional)", value=default_desc_col
+            "Description column name (optional)", value=default_desc_col, key="ss_desc_col"
         )
         sheet_name_input = st.text_input(
             "Sheet name or index (0-based)",
             value=str(default_sheet),
+            key="ss_sheet_name",
             help="Use a sheet name like 'Sheet1' or a zero-based index like '0'.",
         )
-        skiprows = st.number_input("Skip rows at top of file", min_value=0, value=default_skiprows, step=1)
+        skiprows = st.number_input("Skip rows at top of file", min_value=0, value=default_skiprows, step=1, key="ss_skiprows")
 
     # Resolve sheet name to int if numeric
     try:
@@ -82,7 +84,7 @@ def render() -> None:
     file_path = _resolve(file_path_str)
 
     # Preview
-    if st.button("Preview file columns"):
+    if st.button("Preview file columns", key="ss_preview"):
         if not file_path.exists():
             st.error(f"File not found: `{file_path}`")
         else:
@@ -102,7 +104,7 @@ def render() -> None:
 
     col_imp, col_clear = st.columns([2, 1])
     with col_imp:
-        if st.button("Import from file", type="primary"):
+        if st.button("Import from file", type="primary", key="ss_import"):
             if not file_path.exists():
                 st.error(f"File not found: `{file_path}`")
             else:
@@ -129,7 +131,7 @@ def render() -> None:
                     log.exception("SS import error")
 
     with col_clear:
-        if st.button("Clear all SS payments", type="secondary"):
+        if st.button("Clear all SS payments", type="secondary", key="ss_clear"):
             clear_ss_payments()
             st.success("All Social Security payment rows cleared.")
             st.rerun()
@@ -165,7 +167,7 @@ def render() -> None:
     # -------------------------------------------------------------------------
     st.subheader("Payment detail")
 
-    selected_year = st.selectbox("Filter by year", options=["All"] + [str(y) for y in years_available])
+    selected_year = st.selectbox("Filter by year", options=["All"] + [str(y) for y in years_available], key="ss_filter_year")
 
     if selected_year == "All":
         df_view = df_all.copy()
@@ -208,6 +210,7 @@ def render() -> None:
         data=csv_bytes,
         file_name="social_security_payments.csv",
         mime="text/csv",
+        key="ss_download_csv",
     )
 
     # -------------------------------------------------------------------------
@@ -215,8 +218,8 @@ def render() -> None:
     # -------------------------------------------------------------------------
     with st.expander("Delete a payment row"):
         st.markdown("Enter the **ID** of the row you want to delete (visible in the table above).")
-        del_id = st.number_input("Row ID to delete", min_value=1, step=1)
-        if st.button("Delete row", type="secondary"):
+        del_id = st.number_input("Row ID to delete", min_value=1, step=1, key="ss_del_id")
+        if st.button("Delete row", type="secondary", key="ss_delete_row"):
             delete_ss_payment(int(del_id))
             st.success(f"Row {del_id} deleted.")
             st.rerun()

--- a/app/tax_audit.py
+++ b/app/tax_audit.py
@@ -156,18 +156,20 @@ def render() -> None:
 
     col_year, col_quarter, col_model = st.columns([1, 1, 2])
     with col_year:
-        year = st.number_input("Year", min_value=2020, max_value=2030, value=2025, step=1)
+        year = st.number_input("Year", min_value=2020, max_value=2030, value=2025, step=1, key="audit_year")
     with col_quarter:
         quarter = st.selectbox(
             "Quarter",
             options=[1, 2, 3, 4, 0],
             format_func=lambda q: f"Q{q}" if q > 0 else "Annual (Q0 — Modelo 347)",
+            key="audit_quarter",
         )
     with col_model:
         model = st.selectbox(
             "Model",
             options=list(_MODEL_LABELS.keys()),
             format_func=lambda m: _MODEL_LABELS[m],
+            key="audit_model",
         )
 
     st.markdown(f"*{_MODEL_DESCRIPTIONS.get(model, '')}*")
@@ -192,4 +194,5 @@ def render() -> None:
             data=raw_json,
             file_name=f"audit_{model}_{year}_Q{quarter}_{computed_at or 'latest'}.json",
             mime="application/json",
+            key="audit_download_json",
         )


### PR DESCRIPTION
## Summary

- `app/social_security_tab.py`: added `key=` to all 13 keyless widgets (file-path/date/amount/description/sheet-name text inputs, skiprows number input, Preview/Import/Clear buttons, Filter-by-year selectbox, Download CSV button, Delete-row number input and button).
- `app/invoice_explorer.py`: added `key=` to 10 keyless widgets (Direction selectbox, Category/Invoice-type multiselects, Vendor/Client text inputs, date-from/date-to date inputs, Subtotal slider, Rectificativas checkbox, Download CSV button). The Refresh button was already keyed.
- `app/tax_audit.py`: added `key=` to Year number_input, Quarter and Model selectboxes, Download-audit JSON button.
- `app/currency.py` and `app/configuration.py`: already fully keyed in earlier PRs — no changes needed.

## Validation

- `py_compile` on all three modified files: OK
- `pytest tests/ -q`: 83 passed, 0 failed, 0 skipped
- Diff reviewed: pure `key=` additions only, no logic changes, no files outside scope

Closes #41