### PR TITLE
fix: audit bug findings — wire tax-settings knobs, remove unreachable IVA_EU_B2C option

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,16 +327,24 @@ Add a `tax` section to `config.json` (see `config.json.example`), or use the **C
 {
   "tax": {
     "regime": "estimacion_directa_simplificada",
-    "nif": "YOUR_NIF",
     "vat_registered": true,
     "oss_registered": true,
-    "oss_registration_country": "ES",
-    "activity_start_date": "YYYY-MM-DD",
+    "vat_proration_percentage": 100,
     "default_vat_treatment_eu_coaching": "IVA_EU_B2B",
     "default_vat_treatment_eu_newsletter": "OSS_EU"
   }
 }
 ```
+
+Every key above drives a computation:
+
+| Setting | Effect on computation |
+|---------|----------------------|
+| `regime` | Gates the 5% *gastos de difícil justificación* in Modelo 130 — only `estimacion_directa_simplificada` is eligible (Art. 30.2.4ª LIRPF). |
+| `vat_registered` | When `false`, Spanish sales are treated as `IVA_EXEMPT` (no IVA devengado) and no input IVA is deducted in Modelo 303. |
+| `oss_registered` | When `false`, no OSS return is generated (an audit note records why). |
+| `vat_proration_percentage` | Prorrata general applied to deducible IVA (Modelo 303 casilla 28/29). `100` = fully deductible. |
+| `default_vat_treatment_eu_coaching` / `default_vat_treatment_eu_newsletter` | Override the EU (`EU_NOT_SPAIN`) VAT treatment per activity. Defaults: `IVA_EU_B2B` for coaching, `OSS_EU` for newsletter. |
 
 ### Invoice data in tax calculations
 
@@ -441,7 +449,7 @@ The UI shows a summary table plus an expandable drill-down per cell. Each expand
 | Cell | Approximation | Impact |
 |------|--------------|--------|
 | `box_28_base_soportado` (M303) | `box_29_cuota_soportado / 0.21` assumes all deductible expenses at 21% | Display only — does not affect `box_46` or `box_48` |
-| `box_48_resultado` (M303) | 100% proration assumed | User must enter only the deductible portion of IVA in manual entries |
+| `box_48_resultado` (M303) | Prorrata from `tax.vat_proration_percentage` (default 100%) applied to casilla 29 | Set the prorrata in Tax Settings; manual IVA entries should still reflect only genuinely deductible cuota |
 | `box_01_ingresos` (M130) | Ex-VAT base extracted from VAT-inclusive Stripe amounts | Correct for estimación directa — IVA is a pass-through, not income |
 
 ---

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -285,41 +285,37 @@ geographic classification instead of manual overrides.
 
         tax = cfg.get("tax", {})
 
-        st.markdown("##### Identity")
-        col1, col2 = st.columns(2)
-        nif = col1.text_input("NIF / NIE", value=tax.get("nif", ""), key="tax_nif",
-                              help="Your Spanish tax ID (e.g. X5939179G)")
-        activity_start = col2.text_input(
-            "Activity start date (YYYY-MM-DD)",
-            value=tax.get("activity_start_date", ""),
-            key="tax_start_date",
-            help="Date you registered as autónomo — determines IRPF retention rate eligibility",
-        )
-
         st.markdown("##### Fiscal Regime")
         REGIME_OPTIONS = ["estimacion_directa_simplificada", "estimacion_directa_normal", "modulos"]
         regime_val = tax.get("regime", "estimacion_directa_simplificada")
         if regime_val not in REGIME_OPTIONS:
             REGIME_OPTIONS.append(regime_val)
-        regime = st.selectbox("Regime", REGIME_OPTIONS,
-                              index=REGIME_OPTIONS.index(regime_val), key="tax_regime")
-
-        col1, col2 = st.columns(2)
-        vat_registered = col1.checkbox("VAT registered (IVA)", value=tax.get("vat_registered", True),
-                                       key="tax_vat_reg")
-        oss_registered = col2.checkbox("OSS registered", value=tax.get("oss_registered", True),
-                                       key="tax_oss_reg")
+        regime = st.selectbox(
+            "Regime", REGIME_OPTIONS,
+            index=REGIME_OPTIONS.index(regime_val), key="tax_regime",
+            help="Gates the 5% gastos de difícil justificación in Modelo 130 "
+                 "(only estimación directa simplificada is eligible).",
+        )
 
         col1, col2, col3 = st.columns(3)
-        oss_country = col1.text_input("OSS registration country",
-                                      value=tax.get("oss_registration_country", "ES"),
-                                      key="tax_oss_country")
-        fiscal_year_start = col2.number_input("Fiscal year start month", min_value=1, max_value=12,
-                                              value=tax.get("fiscal_year_start_month", 1),
-                                              key="tax_fy_start")
-        vat_proration = col3.number_input("VAT proration % (prorrata)", min_value=0, max_value=100,
-                                          value=tax.get("vat_proration_percentage", 100),
-                                          key="tax_vat_prorrata")
+        vat_registered = col1.checkbox(
+            "VAT registered (IVA)", value=tax.get("vat_registered", True),
+            key="tax_vat_reg",
+            help="If off, Spanish sales are treated as exempt (no IVA devengado) "
+                 "and no input IVA is deducted in Modelo 303.",
+        )
+        oss_registered = col2.checkbox(
+            "OSS registered", value=tax.get("oss_registered", True),
+            key="tax_oss_reg",
+            help="If off, no OSS return is generated for EU B2C digital services.",
+        )
+        vat_proration = col3.number_input(
+            "VAT proration % (prorrata)", min_value=0, max_value=100,
+            value=tax.get("vat_proration_percentage", 100),
+            key="tax_vat_prorrata",
+            help="Prorrata general applied to deducible IVA (Modelo 303 casilla 29). "
+                 "100 = fully deductible.",
+        )
 
         st.markdown("##### EU VAT defaults")
         EU_B2B_OPTIONS = ["IVA_EU_B2B", "IVA_EU_B2C"]
@@ -344,10 +340,6 @@ geographic classification instead of manual overrides.
                 "regime": regime,
                 "vat_registered": vat_registered,
                 "oss_registered": oss_registered,
-                "oss_registration_country": oss_country,
-                "activity_start_date": activity_start,
-                "nif": nif,
-                "fiscal_year_start_month": int(fiscal_year_start),
                 "vat_proration_percentage": int(vat_proration),
                 "default_vat_treatment_eu_coaching": eu_coaching,
                 "default_vat_treatment_eu_newsletter": eu_newsletter,

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -318,13 +318,23 @@ geographic classification instead of manual overrides.
         )
 
         st.markdown("##### EU VAT defaults")
-        EU_B2B_OPTIONS = ["IVA_EU_B2B", "IVA_EU_B2C"]
+        # IVA_EU_B2C is intentionally excluded: compute_modelo_303's aggregation
+        # (src/tax_engine.py) has no devengado box or audit-record bucket for it,
+        # so selecting it would silently drop the income from the quarterly VAT
+        # return. Only offer treatments the engine actually accounts for.
+        EU_B2B_OPTIONS = ["IVA_EU_B2B"]
         EU_NL_OPTIONS = ["OSS_EU", "IVA_EU_B2B"]
+        eu_coaching_val = tax.get("default_vat_treatment_eu_coaching", "IVA_EU_B2B")
+        if eu_coaching_val not in EU_B2B_OPTIONS:
+            # Stale config from before IVA_EU_B2C was removed as a selectable
+            # option (see comment above) — keep it selectable so the page
+            # doesn't crash, but it's no longer offered to new selections.
+            EU_B2B_OPTIONS = EU_B2B_OPTIONS + [eu_coaching_val]
         col1, col2 = st.columns(2)
         eu_coaching = col1.selectbox(
             "EU Coaching VAT treatment",
             EU_B2B_OPTIONS,
-            index=EU_B2B_OPTIONS.index(tax.get("default_vat_treatment_eu_coaching", "IVA_EU_B2B")),
+            index=EU_B2B_OPTIONS.index(eu_coaching_val),
             key="tax_eu_coaching",
         )
         eu_newsletter = col2.selectbox(

--- a/app/tax_obligations.py
+++ b/app/tax_obligations.py
@@ -398,7 +398,7 @@ def render() -> None:
     if "tax" not in config:
         st.warning(
             "Tax configuration is incomplete. Go to **Configuration** tab and fill in the `tax` section "
-            "(NIF, regime, OSS registration, etc.)."
+            "(regime, IVA/OSS registration, EU VAT defaults, etc.)."
         )
 
     col1, col2, col3 = st.columns([2, 2, 2])

--- a/config.json.example
+++ b/config.json.example
@@ -30,10 +30,6 @@
     "regime": "estimacion_directa_simplificada",
     "vat_registered": true,
     "oss_registered": true,
-    "oss_registration_country": "ES",
-    "activity_start_date": "2022-01-01",
-    "nif": "XXXXXXXX",
-    "fiscal_year_start_month": 1,
     "vat_proration_percentage": 100,
     "default_vat_treatment_eu_coaching": "IVA_EU_B2B",
     "default_vat_treatment_eu_newsletter": "OSS_EU"

--- a/src/tax_engine.py
+++ b/src/tax_engine.py
@@ -35,6 +35,36 @@ _DUE_SOON_DAYS = 15
 
 
 # ---------------------------------------------------------------------------
+# App-config plumbing
+# ---------------------------------------------------------------------------
+# The tax engine is config-aware: several ``config.tax`` settings alter the
+# computation (EU VAT-treatment overrides, IVA/OSS registration, prorrata,
+# fiscal regime). The public compute functions take an optional ``config``
+# dict; when it is ``None`` they fall back to an empty dict, i.e. the documented
+# defaults — this keeps the engine pure and the unit tests deterministic. The
+# app entry points (``compute_and_persist_tax_snapshots`` and the tax validator)
+# load the real ``config.json`` once and thread it down.
+
+def _tax_settings(config: Optional[dict]) -> dict:
+    """Return the ``tax`` sub-section of the app config (empty dict if absent)."""
+    return (config or {}).get("tax", {})
+
+
+def load_app_config() -> dict:
+    """Load ``config.json`` for the engine, returning ``{}`` if unavailable.
+
+    Guarded so the engine never crashes on a missing/broken config file — a
+    fresh checkout with no ``config.json`` simply runs with documented defaults.
+    """
+    try:
+        from src.config import load_config
+
+        return load_config()
+    except Exception:  # pragma: no cover - config is optional for the engine
+        return {}
+
+
+# ---------------------------------------------------------------------------
 # Internal DB helpers
 # ---------------------------------------------------------------------------
 
@@ -182,26 +212,28 @@ def _net_amount(row: dict) -> float:
     return round(row["converted_amount"] - row["converted_amount_refunded"], 2)
 
 
-def _get_vat_treatment(row: dict) -> str:
+def _get_vat_treatment(row: dict, config: Optional[dict] = None) -> str:
     """Return stored vat_treatment, or derive it on-the-fly if missing.
 
     The fallback derivation delegates to the shared treatment matrix in
-    ``src.vat_rules`` so the classifier and the engine cannot diverge. No
-    ``config`` is passed here, so the EU B2B fallback is the default
-    ``IVA_EU_B2B`` (matching the historical engine behaviour).
+    ``src.vat_rules`` so the classifier and the engine cannot diverge. The
+    ``config`` dict is threaded through so the EU VAT-treatment overrides
+    (``tax.default_vat_treatment_eu_*``) and the ``tax.vat_registered`` flag
+    are honoured. Rows carrying an explicit stored treatment (manual override)
+    win over the derivation.
     """
     stored = row.get("vat_treatment")
     if stored and stored != "UNKNOWN":
         return stored
     # Derive from activity × geo (fallback for rows not yet VAT-classified)
-    return vat_treatment(row.get("activity_type"), row.get("geo_region"))
+    return vat_treatment(row.get("activity_type"), row.get("geo_region"), config=config)
 
 
 def _oss_country_code(row: dict) -> str:
     return (row.get("oss_country") or row.get("card_country") or "").upper()
 
 
-def _get_vat_base(row: dict) -> float:
+def _get_vat_base(row: dict, config: Optional[dict] = None) -> float:
     """Return the ex-VAT taxable base for a transaction row.
 
     Stripe amounts are VAT-inclusive (the customer paid the gross amount).
@@ -212,15 +244,15 @@ def _get_vat_base(row: dict) -> float:
     if row.get("vat_base_eur") is not None:
         return row["vat_base_eur"]
     return vat_base_from_inclusive(
-        _net_amount(row), _get_vat_treatment(row), _oss_country_code(row)
+        _net_amount(row), _get_vat_treatment(row, config), _oss_country_code(row)
     )
 
 
-def _get_vat_amount(row: dict) -> float:
+def _get_vat_amount(row: dict, config: Optional[dict] = None) -> float:
     if row.get("vat_amount_eur") is not None:
         return row["vat_amount_eur"]
     return vat_amount_on_base(
-        _get_vat_base(row), _get_vat_treatment(row), _oss_country_code(row)
+        _get_vat_base(row, config), _get_vat_treatment(row, config), _oss_country_code(row)
     )
 
 
@@ -259,9 +291,19 @@ def _previous_modelo130_payments(year: int, quarter: int, conn: sqlite3.Connecti
 # Public computation functions
 # ---------------------------------------------------------------------------
 
-def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> Modelo303Result:
-    """Compute Modelo 303 (quarterly VAT return) for the given quarter."""
+def compute_modelo_303(
+    year: int, quarter: int, db_conn: sqlite3.Connection, config: Optional[dict] = None
+) -> Modelo303Result:
+    """Compute Modelo 303 (quarterly VAT return) for the given quarter.
+
+    ``config`` (the app config dict) drives the EU VAT-treatment overrides, the
+    ``tax.vat_registered`` flag (unregistered → no devengado / no deducible IVA)
+    and ``tax.vat_proration_percentage`` (prorrata applied to deducible IVA).
+    """
     result = Modelo303Result(year=year, quarter=quarter)
+    tax_cfg = _tax_settings(config)
+    vat_registered = tax_cfg.get("vat_registered", True) is not False
+    proration = tax_cfg.get("vat_proration_percentage", 100) / 100.0
     rows = _load_classified_for_quarter(year, quarter, db_conn)
 
     # Aggregate Stripe transactions by (geo_region, activity_type, treatment).
@@ -271,9 +313,9 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
     _agg: dict[tuple, dict] = {}
 
     for row in rows:
-        treatment = _get_vat_treatment(row)
-        base = _get_vat_base(row)   # ex-VAT base (VAT-inclusive extraction applied)
-        vat = _get_vat_amount(row)
+        treatment = _get_vat_treatment(row, config)
+        base = _get_vat_base(row, config)   # ex-VAT base (VAT-inclusive extraction applied)
+        vat = _get_vat_amount(row, config)
         geo = row.get("geo_region") or "UNKNOWN"
         act = row.get("activity_type") or "UNKNOWN"
         oss_cc = (row.get("oss_country") or row.get("card_country") or "").upper() if treatment == "OSS_EU" else ""
@@ -378,17 +420,18 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
 
     # Deductible IVA from manual entries (current quarter only) + invoices.
     # Casilla 29 = cuota (IVA amount); casilla 28 = its corresponding base.
-    result.box_29_cuota_soportado = round(
-        inv_iva_soportado
-        + _get_tax_entries_total(year, quarter, "IVA_SOPORTADO", db_conn, ytd=False),
-        2,
-    )
-    manual_iva = result.box_29_cuota_soportado - inv_iva_soportado
-    if manual_iva > 0:
-        manual_base = manual_iva / 0.21
-        result.box_28_base_soportado = round(inv_base_soportado + manual_base, 2)
+    # Not IVA-registered → no input VAT is deductible. Otherwise the prorrata
+    # (tax.vat_proration_percentage) scales the deductible cuota and its base
+    # (prorrata general — Art. 104 LIVA); 100% leaves both unchanged.
+    manual_iva = _get_tax_entries_total(year, quarter, "IVA_SOPORTADO", db_conn, ytd=False)
+    if not vat_registered:
+        result.box_29_cuota_soportado = 0.0
+        result.box_28_base_soportado = 0.0
     else:
-        result.box_28_base_soportado = round(inv_base_soportado, 2)
+        raw_iva_soportado = inv_iva_soportado + manual_iva
+        raw_base_soportado = inv_base_soportado + (manual_iva / 0.21 if manual_iva > 0 else 0.0)
+        result.box_29_cuota_soportado = round(raw_iva_soportado * proration, 2)
+        result.box_28_base_soportado = round(raw_base_soportado * proration, 2)
 
     # Round accumulations
     result.box_01_base = round(result.box_01_base, 2)
@@ -399,7 +442,8 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
     result.export_base = round(result.export_base, 2)
 
     result.box_46_diferencia = round(result.box_03_cuota - result.box_29_cuota_soportado, 2)
-    result.box_48_resultado = result.box_46_diferencia  # simplified (100% proration)
+    # Prorrata is already applied to box_29 above, so box_48 = box_46 directly.
+    result.box_48_resultado = result.box_46_diferencia
 
     # --- Audit trail ---
     def _a(cell, label, formula, value, **inputs):
@@ -425,16 +469,20 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
            result.box_59_intracom_entregas,
            records=recs_eu_b2b),
         _a("box_28_base_soportado",
-           "Base IVA soportado (facturas + estimación 21% para entradas manuales)",
-           "SUM(subtotal_eur * deductible_pct/100) FROM invoices + manual_IVA / 0.21",
+           "Base IVA soportado (facturas + estimación 21% para entradas manuales, × prorrata)",
+           "(SUM(subtotal_eur * deductible_pct/100) FROM invoices + manual_IVA / 0.21) × prorrata",
            result.box_28_base_soportado,
-           inv_base_sum=round(inv_base_soportado, 2)),
+           inv_base_sum=round(inv_base_soportado, 2),
+           vat_registered=vat_registered, proration_pct=round(proration * 100, 2)),
         _a("box_29_cuota_soportado",
-           "IVA soportado deducible — todas las facturas recibidas del trimestre",
-           "SUM(iva_amount * deductible_pct/100) FROM invoices WHERE direction='in' AND quarter=Q "
-           "+ SUM(amount_eur) FROM quarterly_tax_entries WHERE entry_type='IVA_SOPORTADO' AND quarter=Q",
+           "IVA soportado deducible — facturas recibidas + entradas manuales (× prorrata)",
+           "(SUM(iva_amount * deductible_pct/100) FROM invoices WHERE direction='in' AND quarter=Q "
+           "+ SUM(amount_eur) FROM quarterly_tax_entries WHERE entry_type='IVA_SOPORTADO' AND quarter=Q) "
+           "× prorrata  [0 if not IVA-registered]",
            result.box_29_cuota_soportado,
            inv_iva_deductible=round(inv_iva_soportado, 2),
+           manual_iva=round(manual_iva, 2),
+           vat_registered=vat_registered, proration_pct=round(proration * 100, 2),
            records=recs_soportado),
         _a("box_46_diferencia",
            "Diferencia (IVA devengado − IVA deducible)",
@@ -443,9 +491,10 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
            box_03_cuota=result.box_03_cuota, box_29_cuota_soportado=result.box_29_cuota_soportado),
         _a("box_48_resultado",
            "Resultado a ingresar / devolver",
-           "= box_46_diferencia  [100% prorrata; no prior-period compensation applied]",
+           "= box_46_diferencia  [prorrata applied to box_29; no prior-period compensation applied]",
            result.box_48_resultado,
-           box_46_diferencia=result.box_46_diferencia),
+           box_46_diferencia=result.box_46_diferencia,
+           proration_pct=round(proration * 100, 2)),
         _a("oss_base",
            "Base OSS — servicios digitales B2C UE",
            "SUM(vat_base_eur) WHERE vat_treatment = 'OSS_EU'  [declarar por OSS, no en 303]",
@@ -465,13 +514,23 @@ def compute_modelo_303(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
     return result
 
 
-def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> Modelo130Result:
-    """Compute Modelo 130 (quarterly IRPF advance) for the given quarter."""
+def compute_modelo_130(
+    year: int, quarter: int, db_conn: sqlite3.Connection, config: Optional[dict] = None
+) -> Modelo130Result:
+    """Compute Modelo 130 (quarterly IRPF advance) for the given quarter.
+
+    ``config`` drives the EU VAT-treatment overrides (via the shared derivation)
+    and the ``tax.regime`` gate on the 5% gastos de difícil justificación, which
+    only applies under *estimación directa simplificada*.
+    """
     result = Modelo130Result(year=year, quarter=quarter)
+    tax_cfg = _tax_settings(config)
+    regime = tax_cfg.get("regime", "estimacion_directa_simplificada")
+    gdj_eligible = regime == "estimacion_directa_simplificada"
     # Stripe income (transactions table)
     rows = _load_classified_ytd(year, quarter, db_conn)
     n_stripe_rows = len(rows)
-    stripe_income = sum(_get_vat_base(r) for r in rows)
+    stripe_income = sum(_get_vat_base(r, config) for r in rows)
 
     # Non-Stripe income: manually-issued invoices (direction='out')
     income_invs = _load_income_invoices_ytd(year, quarter, db_conn)
@@ -523,9 +582,9 @@ def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
 
     result.box_03_rendimiento = round(result.box_01_ingresos - result.box_02_gastos, 2)
 
-    # Gastos de difícil justificación: 5% of rendimiento neto previo, capped at €2,000/year
-    # Art. 30.2.4ª LIRPF — estimación directa simplificada
-    if result.box_03_rendimiento > 0:
+    # Gastos de difícil justificación: 5% of rendimiento neto previo, capped at €2,000/year.
+    # Art. 30.2.4ª LIRPF — applies ONLY under estimación directa simplificada.
+    if result.box_03_rendimiento > 0 and gdj_eligible:
         raw_gdj = result.box_03_rendimiento * 0.05
         result.gastos_dificil_justificacion = round(min(raw_gdj, 2000.0), 2)
         gdj_capped = raw_gdj > 2000.0
@@ -566,7 +625,7 @@ def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
     # Mirrors the Quarter Report view the gestor uses.
     _stripe_agg: dict[tuple, dict] = {}
     for r in rows:
-        treatment = _get_vat_treatment(r)
+        treatment = _get_vat_treatment(r, config)
         geo = r.get("geo_region") or "UNKNOWN"
         act = r.get("activity_type") or "UNKNOWN"
         key = (geo, act, treatment)
@@ -574,7 +633,7 @@ def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
             _stripe_agg[key] = {"n": 0, "gross_eur": 0.0, "base_eur": 0.0}
         _stripe_agg[key]["n"] += 1
         _stripe_agg[key]["gross_eur"] = round(_stripe_agg[key]["gross_eur"] + _net_amount(r), 2)
-        _stripe_agg[key]["base_eur"] = round(_stripe_agg[key]["base_eur"] + _get_vat_base(r), 2)
+        _stripe_agg[key]["base_eur"] = round(_stripe_agg[key]["base_eur"] + _get_vat_base(r, config), 2)
 
     stripe_income_records = [
         {
@@ -642,10 +701,12 @@ def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
            box_01_ingresos=result.box_01_ingresos, box_02_gastos=result.box_02_gastos),
         _a("gastos_dificil_justificacion",
            "Gastos de difícil justificación (5%, máx €2.000/año)",
-           "min(box_03_rendimiento × 5%, 2000)  [Art. 30.2.4ª LIRPF — estimación directa simplificada]",
+           "min(box_03_rendimiento × 5%, 2000) if regime='estimacion_directa_simplificada' else 0  "
+           "[Art. 30.2.4ª LIRPF]",
            result.gastos_dificil_justificacion,
            box_03_rendimiento=result.box_03_rendimiento, rate=0.05, cap_eur=2000.0,
-           raw_5pct=round(raw_gdj, 2), cap_applied=gdj_capped),
+           raw_5pct=round(raw_gdj, 2), cap_applied=gdj_capped,
+           regime=regime, gdj_eligible=gdj_eligible),
         _a("rendimiento_neto",
            "Rendimiento neto (base de cálculo IRPF)",
            "box_03_rendimiento − gastos_dificil_justificacion",
@@ -689,14 +750,20 @@ def compute_modelo_130(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
     return result
 
 
-def compute_modelo_349(year: int, quarter: int, db_conn: sqlite3.Connection) -> Modelo349Result:
-    """Compute Modelo 349 (intra-EU operations summary) for the given quarter."""
+def compute_modelo_349(
+    year: int, quarter: int, db_conn: sqlite3.Connection, config: Optional[dict] = None
+) -> Modelo349Result:
+    """Compute Modelo 349 (intra-EU operations summary) for the given quarter.
+
+    ``config`` is threaded through the VAT-treatment derivation so the EU
+    coaching/newsletter overrides decide which rows count as ``IVA_EU_B2B``.
+    """
     result = Modelo349Result(year=year, quarter=quarter)
     rows = _load_classified_for_quarter(year, quarter, db_conn)
 
     by_vat_id: dict[str, dict] = {}
     for row in rows:
-        treatment = _get_vat_treatment(row)
+        treatment = _get_vat_treatment(row, config)
         if treatment != "IVA_EU_B2B":
             continue
         vat_id = row.get("buyer_vat_id") or "UNKNOWN"
@@ -765,19 +832,36 @@ def compute_modelo_349(year: int, quarter: int, db_conn: sqlite3.Connection) -> 
     return result
 
 
-def compute_oss_return(year: int, quarter: int, db_conn: sqlite3.Connection) -> OSSReturnResult:
-    """Compute OSS quarterly return (B2C digital services to EU non-Spain customers)."""
+def compute_oss_return(
+    year: int, quarter: int, db_conn: sqlite3.Connection, config: Optional[dict] = None
+) -> OSSReturnResult:
+    """Compute OSS quarterly return (B2C digital services to EU non-Spain customers).
+
+    When ``tax.oss_registered`` is false the taxpayer is not enrolled in the One
+    Stop Shop, so no OSS return is produced (an audit note records why). Otherwise
+    ``config`` is threaded through the VAT-treatment derivation.
+    """
     result = OSSReturnResult(year=year, quarter=quarter)
+    if _tax_settings(config).get("oss_registered", True) is False:
+        result.audit = [AuditEntry(
+            model="OSS", year=year, quarter=quarter,
+            cell="oss_not_registered",
+            label="OSS no aplicable — no registrado en el régimen One Stop Shop",
+            formula="tax.oss_registered = false → no OSS return generated",
+            value=0.0,
+            inputs_json=json.dumps({"oss_registered": False}),
+        )]
+        return result
     rows = _load_classified_for_quarter(year, quarter, db_conn)
 
     by_country: dict[str, dict] = defaultdict(lambda: {"count": 0, "base": 0.0, "vat": 0.0})
     for row in rows:
-        treatment = _get_vat_treatment(row)
+        treatment = _get_vat_treatment(row, config)
         if treatment != "OSS_EU":
             continue
         cc = (row.get("oss_country") or row.get("card_country") or "UNKNOWN").upper()
-        base = _get_vat_base(row)
-        vat = _get_vat_amount(row)
+        base = _get_vat_base(row, config)
+        vat = _get_vat_amount(row, config)
         by_country[cc]["count"] += 1
         by_country[cc]["base"] += base
         by_country[cc]["vat"] += vat
@@ -1016,12 +1100,16 @@ def get_tax_calendar(year: int, db_conn: Optional[sqlite3.Connection] = None) ->
 
 
 def compute_and_persist_tax_snapshots(
-    year: int, quarter: int, db_conn: sqlite3.Connection,
+    year: int, quarter: int, db_conn: sqlite3.Connection, config: Optional[dict] = None
 ) -> str:
     """Run all obligation engines for the selected period and persist JSON snapshots.
 
     Quarterly models (303, 130, OSS, 349) use ``quarter``; Modelo 347 is annual and is
     stored with ``quarter`` = ``TAX_SNAPSHOT_QUARTER_ANNUAL`` (0).
+
+    The app config is loaded once here and threaded through every engine so the
+    ``config.tax`` settings (EU VAT overrides, IVA/OSS registration, prorrata,
+    regime) drive the computation. Callers may pass an explicit ``config`` dict.
 
     Returns the shared ISO ``computed_at`` timestamp written on every snapshot row.
     """
@@ -1032,21 +1120,24 @@ def compute_and_persist_tax_snapshots(
     )
     from src.tax_snapshot_codec import encode_snapshot
 
+    if config is None:
+        config = load_app_config()
+
     computed_at = datetime.now().isoformat(timespec="seconds")
 
-    r303 = compute_modelo_303(year, quarter, db_conn)
+    r303 = compute_modelo_303(year, quarter, db_conn, config)
     upsert_tax_snapshot_conn(db_conn, year, quarter, "303", encode_snapshot("303", r303), computed_at)
     upsert_audit_entries_conn(db_conn, r303.audit, computed_at)
 
-    r130 = compute_modelo_130(year, quarter, db_conn)
+    r130 = compute_modelo_130(year, quarter, db_conn, config)
     upsert_tax_snapshot_conn(db_conn, year, quarter, "130", encode_snapshot("130", r130), computed_at)
     upsert_audit_entries_conn(db_conn, r130.audit, computed_at)
 
-    r_oss = compute_oss_return(year, quarter, db_conn)
+    r_oss = compute_oss_return(year, quarter, db_conn, config)
     upsert_tax_snapshot_conn(db_conn, year, quarter, "OSS", encode_snapshot("OSS", r_oss), computed_at)
     upsert_audit_entries_conn(db_conn, r_oss.audit, computed_at)
 
-    r349 = compute_modelo_349(year, quarter, db_conn)
+    r349 = compute_modelo_349(year, quarter, db_conn, config)
     upsert_tax_snapshot_conn(db_conn, year, quarter, "349", encode_snapshot("349", r349), computed_at)
     upsert_audit_entries_conn(db_conn, r349.audit, computed_at)
 

--- a/src/tax_validator.py
+++ b/src/tax_validator.py
@@ -17,6 +17,7 @@ from src.tax_engine import (
     compute_modelo_130,
     compute_modelo_303,
     compute_modelo_349,
+    load_app_config,
 )
 
 _YAML_PATH = Path(__file__).parent.parent / "tmp" / "validation" / "validation.yaml"
@@ -105,7 +106,7 @@ def validate_modelo_130(
     year: int, quarter: int, conn: sqlite3.Connection, filings: list[dict]
 ) -> ModelValidationResult:
     filing = _find_filing(filings, "130", year, quarter)
-    computed = compute_modelo_130(year, quarter, conn)
+    computed = compute_modelo_130(year, quarter, conn, load_app_config())
     period = f"{year} Q{quarter}"
 
     if filing is None:
@@ -151,7 +152,7 @@ def validate_modelo_303(
     year: int, quarter: int, conn: sqlite3.Connection, filings: list[dict]
 ) -> ModelValidationResult:
     filing = _find_filing(filings, "303", year, quarter)
-    computed = compute_modelo_303(year, quarter, conn)
+    computed = compute_modelo_303(year, quarter, conn, load_app_config())
     period = f"{year} Q{quarter}"
 
     if filing is None:
@@ -189,7 +190,7 @@ def validate_modelo_349(
     year: int, quarter: int, conn: sqlite3.Connection, filings: list[dict]
 ) -> ModelValidationResult:
     filing = _find_filing(filings, "349", year, quarter)
-    computed = compute_modelo_349(year, quarter, conn)
+    computed = compute_modelo_349(year, quarter, conn, load_app_config())
     period = f"{year} Q{quarter}"
 
     if filing is None:
@@ -230,11 +231,12 @@ def validate_modelo_390(
     filing = _find_filing(filings, "390", year, None)
     period = f"{year} Annual"
 
+    config = load_app_config()
     # Aggregate all 4 quarters
     agg = dict(base_21=0.0, cuota_21=0.0, intracom=0.0, export=0.0,
                oss=0.0, soportado_base=0.0, soportado_cuota=0.0)
     for q in range(1, 5):
-        m = compute_modelo_303(year, q, conn)
+        m = compute_modelo_303(year, q, conn, config)
         agg["base_21"]         += m.box_01_base
         agg["cuota_21"]        += m.box_03_cuota
         agg["intracom"]        += m.box_59_intracom_entregas
@@ -246,7 +248,7 @@ def validate_modelo_390(
 
     agg_resultado   = round(agg["cuota_21"] - agg["soportado_cuota"], 2)
     agg_vol_total   = round(agg["base_21"] + agg["intracom"] + agg["export"] + agg["oss"], 2)
-    m130 = compute_modelo_130(year, 4, conn)
+    m130 = compute_modelo_130(year, 4, conn, config)
 
     # M130 cross-check filed reference: the annual income computed for Modelo 390
     # must be reconciled against the income the gestor actually filed on Modelo 130,

--- a/src/vat_rules.py
+++ b/src/vat_rules.py
@@ -40,31 +40,32 @@ def vat_treatment(
     The single rule set:
 
     - ``OUTSIDE_EU`` → ``IVA_EXPORT``
-    - ``SPAIN`` → ``IVA_ES_21``
-    - ``EU_NOT_SPAIN`` + ``NEWSLETTER`` → ``OSS_EU``
-    - ``EU_NOT_SPAIN`` + other activity → EU B2B reverse charge. The treatment
-      may be overridden per-activity via
-      ``tax.default_vat_treatment_eu_<activity>`` in ``config``; defaults to
-      ``IVA_EU_B2B``.
+    - ``SPAIN`` → ``IVA_ES_21`` (or ``IVA_EXEMPT`` when the taxpayer is not
+      IVA-registered, i.e. ``tax.vat_registered`` is false — franquicia/no
+      domestic IVA charged).
+    - ``EU_NOT_SPAIN`` → EU treatment, per-activity. The treatment may be
+      overridden via ``tax.default_vat_treatment_eu_<activity>`` in ``config``;
+      the per-activity default is ``OSS_EU`` for ``NEWSLETTER`` (B2C digital
+      services) and ``IVA_EU_B2B`` (reverse charge) for everything else.
     - anything else → ``UNKNOWN``
 
     ``config`` is the full app config dict (with a ``tax`` section). When
-    ``None``, the EU B2B default ``IVA_EU_B2B`` is used.
+    ``None``, the documented defaults are used.
     """
     geo = geo or "UNKNOWN"
     activity = activity or "UNKNOWN"
+    tax_cfg = (config or {}).get("tax", {})
 
     if geo == "OUTSIDE_EU":
         return "IVA_EXPORT"
     if geo == "SPAIN":
+        # Not IVA-registered (franquicia) → no domestic IVA is charged.
+        if tax_cfg.get("vat_registered", True) is False:
+            return "IVA_EXEMPT"
         return "IVA_ES_21"
     if geo == "EU_NOT_SPAIN":
-        if activity == "NEWSLETTER":
-            return "OSS_EU"
-        tax_cfg = (config or {}).get("tax", {})
-        return tax_cfg.get(
-            f"default_vat_treatment_eu_{activity.lower()}", "IVA_EU_B2B"
-        )
+        default = "OSS_EU" if activity == "NEWSLETTER" else "IVA_EU_B2B"
+        return tax_cfg.get(f"default_vat_treatment_eu_{activity.lower()}", default)
     return "UNKNOWN"
 
 

--- a/tests/test_tax_engine.py
+++ b/tests/test_tax_engine.py
@@ -239,6 +239,72 @@ class TestModelo349:
         assert result.total == pytest.approx(500.0)
 
 
+class TestConfigDrivenTaxSettings:
+    """The config.tax settings must actually drive the computations."""
+
+    def test_regime_normal_disables_gastos_dificil(self, db_conn):
+        _insert_tx(db_conn, id="t1", converted_amount=1000.0, activity_type="COACHING")
+        # estimación directa normal → no 5% gastos de difícil justificación
+        cfg = {"tax": {"regime": "estimacion_directa_normal"}}
+        result = compute_modelo_130(2025, 1, db_conn, cfg)
+        assert result.gastos_dificil_justificacion == 0.0
+        # Simplificada (default) DOES apply it — sanity contrast
+        result_simpl = compute_modelo_130(2025, 1, db_conn, {"tax": {}})
+        assert result_simpl.gastos_dificil_justificacion == pytest.approx(41.32)
+
+    def test_vat_proration_scales_deducible_iva(self, db_conn):
+        _insert_tx(db_conn, id="t1", converted_amount=121.0, geo_region="SPAIN")
+        db_conn.execute(
+            "INSERT INTO quarterly_tax_entries (year, quarter, entry_type, amount_eur) "
+            "VALUES (2025, 1, 'IVA_SOPORTADO', 500.0)"
+        )
+        db_conn.commit()
+        cfg = {"tax": {"vat_proration_percentage": 50}}
+        result = compute_modelo_303(2025, 1, db_conn, cfg)
+        # 500 soportado × 50% prorrata = 250 deducible
+        assert result.box_29_cuota_soportado == pytest.approx(250.0)
+
+    def test_not_vat_registered_exempts_spanish_sales(self, db_conn):
+        # No stored vat_treatment → derivation runs and honours the config flag
+        _insert_tx(db_conn, id="t1", converted_amount=121.0, geo_region="SPAIN",
+                   vat_treatment=None)
+        db_conn.execute(
+            "INSERT INTO quarterly_tax_entries (year, quarter, entry_type, amount_eur) "
+            "VALUES (2025, 1, 'IVA_SOPORTADO', 500.0)"
+        )
+        db_conn.commit()
+        cfg = {"tax": {"vat_registered": False}}
+        result = compute_modelo_303(2025, 1, db_conn, cfg)
+        assert result.box_01_base == 0.0        # no devengado
+        assert result.box_03_cuota == 0.0
+        assert result.box_29_cuota_soportado == 0.0  # no deducible input IVA
+        assert result.box_28_base_soportado == 0.0
+
+    def test_not_oss_registered_produces_no_oss_return(self, db_conn):
+        _insert_tx(db_conn, id="t1", converted_amount=100.0, geo_region="EU_NOT_SPAIN",
+                   activity_type="NEWSLETTER", vat_treatment="OSS_EU",
+                   vat_base_eur=100.0, vat_amount_eur=19.0, oss_country="DE")
+        cfg = {"tax": {"oss_registered": False}}
+        result = compute_oss_return(2025, 1, db_conn, cfg)
+        assert result.rows == []
+        assert result.total_base == 0.0
+        assert any(a.cell == "oss_not_registered" for a in result.audit)
+
+    def test_eu_newsletter_override_routes_to_349(self, db_conn):
+        # Newsletter defaults to OSS_EU, but the config override makes it EU B2B,
+        # which then surfaces on Modelo 349. Row carries no stored treatment.
+        _insert_tx(db_conn, id="t1", converted_amount=300.0, geo_region="EU_NOT_SPAIN",
+                   activity_type="NEWSLETTER", vat_treatment=None,
+                   email_meta="sub@eu.com", buyer_vat_id="DE999")
+        # Default (OSS_EU) → not on 349
+        assert len(compute_modelo_349(2025, 1, db_conn, {"tax": {}}).rows) == 0
+        # Override → treated as IVA_EU_B2B → appears on 349
+        cfg = {"tax": {"default_vat_treatment_eu_newsletter": "IVA_EU_B2B"}}
+        result = compute_modelo_349(2025, 1, db_conn, cfg)
+        assert len(result.rows) == 1
+        assert result.rows[0].total_amount == pytest.approx(300.0)
+
+
 class TestTaxSnapshotPersistence:
     def test_persist_and_load_roundtrip(self, db_conn):
         _insert_tx(db_conn)


### PR DESCRIPTION
## Summary

- Resolves the 9 tax-settings-knob findings from `/codebase-audit` in issue #50: wired `vat_registered`, `oss_registered`, `vat_proration_percentage`, `regime`, and `default_vat_treatment_eu_coaching`/`_newsletter` into their actual computation sites; removed `fiscal_year_start_month`, `activity_start_date`, `oss_registration_country`, and `nif` as dead/invalid knobs (widget + config key).
- Follow-up fix for a gap surfaced during finish-review: the `default_vat_treatment_eu_coaching` dropdown still offered `IVA_EU_B2C`, but `compute_modelo_303`'s aggregation (`src/tax_engine.py`) has no devengado box or audit-record bucket for that treatment — selecting it would have silently dropped EU coaching income from the quarterly VAT return with zero audit trail. **Removed `IVA_EU_B2C` from the EU VAT treatment dropdown** (`EU_B2B_OPTIONS` in `app/configuration.py`) as the minimal safe fix, rather than adding new tax-computation logic for an unsupported VAT treatment, which needs separate domain sign-off. Also guarded the selectbox index lookup so a stale `config.json` that already has `IVA_EU_B2C` saved doesn't crash the Configuration page.

## Commits

| SHA | What | Why |
|-----|------|-----|
| `354bb0a` | Wire 5 tax-settings knobs into computation (`vat_registered`, `oss_registered`, `vat_proration_percentage`, `regime`, EU VAT overrides); remove 4 dead/invalid knobs | Close the 9 audit findings in #50 — a UI section that promised to drive tax computation but silently did nothing |
| `1367840` | Remove `IVA_EU_B2C` from the EU VAT treatment override dropdown; guard stale-config index lookup | Close a reachability gap the first commit's wiring newly exposed — the dropdown could select a VAT treatment the engine doesn't account for |

## Validation

- `pytest -v`: 88 passed
- `py_compile` on modified modules: OK
- Diff reviewed against issue #50's 9-item checklist — all confirmed satisfied

Closes #50