### PR TITLE
chore: clean up stale audit findings (#52)

### DIFF
--- a/app/social_security_tab.py
+++ b/app/social_security_tab.py
@@ -14,7 +14,6 @@ from src.social_security import (
     clear_ss_payments,
     delete_ss_payment,
     get_ss_payments,
-    get_ss_total_for_period,
     load_bank_export,
     upsert_ss_payments,
 )

--- a/src/social_security.py
+++ b/src/social_security.py
@@ -1,13 +1,13 @@
 """Social Security (Seguridad Social) cuotas import from bank account exports."""
 from __future__ import annotations
 
-import sqlite3
 from datetime import date, datetime
 from pathlib import Path
 from typing import Optional
 
 import pandas as pd
 
+from src.database import get_connection
 from src.logger import get_logger
 
 log = get_logger(__name__)
@@ -119,12 +119,6 @@ def load_bank_export(
 # ---------------------------------------------------------------------------
 # DB helpers (called by database.py's init_db, but also directly usable)
 # ---------------------------------------------------------------------------
-
-def get_connection(db_path: Optional[str | Path] = None) -> sqlite3.Connection:
-    """Return a sqlite3 connection with row_factory set."""
-    from src.database import get_connection as _db_get_connection
-    return _db_get_connection(db_path)
-
 
 def upsert_ss_payments(
     rows: list[dict],

--- a/src/tax_engine.py
+++ b/src/tax_engine.py
@@ -209,6 +209,8 @@ def _load_income_invoices_for_quarter(
 
 
 def _net_amount(row: dict) -> float:
+    # Row-dict counterpart of Payment.net_amount (src/models.py) — same formula,
+    # different input shape (SQL row dict vs. Pydantic model); kept in sync by hand.
     return round(row["converted_amount"] - row["converted_amount_refunded"], 2)
 
 


### PR DESCRIPTION
## Summary
- Removes `src/social_security.py`'s thin `get_connection()` re-export wrapper; its six intra-module callers now import `src.database.get_connection` directly (also drops the now-unused `sqlite3` import).
- Drops the unused `get_ss_total_for_period` import in `app/social_security_tab.py`.
- Adds a one-line comment on `tax_engine._net_amount` pointing at `Payment.net_amount` (`src/models.py`) so the two "net amount" formulas — one over SQL row dicts, one over Pydantic objects — don't look like accidental divergence to a future reader.

The `vat_treatment(config=...)` dead-parameter finding from the audit is intentionally left alone — the issue body flags it as owned by the separate bug-bucket issue.

## Validation
- `py_compile` on all three changed files: clean.
- Full suite: `.\.venv\Scripts\python.exe -m pytest -v` — 88 passed, 0 failed, 0 skipped.
- Behavioural probe: ran a standalone script against a temp SQLite DB exercising every `social_security.py` public function (`upsert_ss_payments`, `get_ss_payments`, `get_ss_total_for_period`, `get_ss_total_ytd`, `get_ss_count`, `delete_ss_payment`, `clear_ss_payments`) end-to-end through the new direct `src.database.get_connection` import — all assertions passed, confirming the wrapper removal didn't change behavior. Production `data/accounting.db` untouched (verified unchanged mtime).
- `git diff main...HEAD` sanity sweep: 3 files changed, 3 insertions / 8 deletions, no scope creep.
- No CI configured in this repo (no `.github/workflows`) — nothing to await.

## Test plan
- [x] `py_compile` clean on changed files
- [x] Full pytest suite green (88/88)
- [x] Behavioural probe of refactored `social_security.py` against temp DB
- [x] Diff scoped to only the in-scope findings

Closes #52