### PR TITLE
chore: add explicit stable key= to 8 Streamlit widgets missing them

### DIFF
--- a/app/invoice_ocr_tab.py
+++ b/app/invoice_ocr_tab.py
@@ -339,7 +339,7 @@ def render() -> None:
         # ── Clear table button (with confirmation) ───────────────────────────
         with st.expander("Danger zone", expanded=False):
             if not st.session_state.get("confirm_clear_invoices"):
-                if st.button("Clear invoice table", type="secondary"):
+                if st.button("Clear invoice table", type="secondary", key="inv_ocr_clear_start"):
                     st.session_state["confirm_clear_invoices"] = True
                     st.rerun()
             else:
@@ -348,12 +348,12 @@ def render() -> None:
                     "The PDF files themselves are not touched."
                 )
                 col_yes, col_no = st.columns(2)
-                if col_yes.button("Yes, delete everything", type="primary"):
+                if col_yes.button("Yes, delete everything", type="primary", key="inv_ocr_clear_confirm"):
                     n = clear_invoices()
                     st.session_state["confirm_clear_invoices"] = False
                     st.success(f"Deleted {n} record(s).")
                     st.rerun()
-                if col_no.button("Cancel"):
+                if col_no.button("Cancel", key="inv_ocr_clear_cancel"):
                     st.session_state["confirm_clear_invoices"] = False
                     st.rerun()
 
@@ -392,6 +392,7 @@ def render() -> None:
                     if st.button(
                         f"Delete {len(selected_indices)} selected record(s)",
                         type="primary",
+                        key="inv_ocr_delete_selected",
                     ):
                         ids_to_delete = [
                             df_display.iloc[i]["id"]

--- a/app/tax_obligations.py
+++ b/app/tax_obligations.py
@@ -265,9 +265,9 @@ def _render_manual_entries(year: int, quarter: int) -> None:
             ["IVA_SOPORTADO", "GASTOS_DEDUCIBLES", "RETENCIONES_SOPORTADAS", "OTHER"],
         )
         amount = col2.number_input("Amount (€)", min_value=0.0, step=0.01, format="%.2f")
-        description = st.text_input("Description")
-        notes = st.text_area("Notes", height=70)
-        if st.form_submit_button("Add Entry"):
+        description = st.text_input("Description", key=f"add_entry_desc_{year}_{quarter}")
+        notes = st.text_area("Notes", height=70, key=f"add_entry_notes_{year}_{quarter}")
+        if st.form_submit_button("Add Entry", key=f"add_entry_submit_{year}_{quarter}"):
             if amount > 0:
                 add_tax_entry(year, quarter, entry_type, amount, description, notes)
                 st.success("Entry added.")

--- a/app/tax_validation.py
+++ b/app/tax_validation.py
@@ -140,7 +140,7 @@ def render() -> None:
 
     col_info, col_btn = st.columns([5, 1])
     with col_btn:
-        if st.button("↺ Refresh", help="Clear cached results and re-run all validations"):
+        if st.button("↺ Refresh", help="Clear cached results and re-run all validations", key="tv_refresh"):
             _cached_validations.clear()
 
     with st.spinner("Running validations…"):


### PR DESCRIPTION
## Summary
- Adds an explicit, stable `key=` to the 8 Streamlit widgets flagged by the audit issue, matching the repo's CLAUDE.md Streamlit convention: *"Every widget needs a stable, explicit key="*.
- `app/tax_validation.py:143` — Refresh button -> `key="tv_refresh"`
- `app/invoice_ocr_tab.py:342,351,356,392-395` — danger-zone Clear/Confirm/Cancel buttons and the multi-row delete button -> `key="inv_ocr_clear_start"` / `"inv_ocr_clear_confirm"` / `"inv_ocr_clear_cancel"` / `"inv_ocr_delete_selected"`
- `app/tax_obligations.py:268-270` — manual-entry Description/Notes/Add Entry widgets, scoped per period -> `key=f"add_entry_desc_{year}_{quarter}"` / `f"add_entry_notes_{year}_{quarter}"` / `f"add_entry_submit_{year}_{quarter}"`
- No behavior change — purely widget-identity stability, mirroring PR #49's earlier pass over SS/Invoice Explorer/Tax Audit tabs.

## Validation
- `py_compile` on all 3 changed files: clean.
- `pytest -v`: 88 passed, 0 failed, 0 skipped.
- Live browser click-through (headed, isolated port) of all 8 widgets: Invoice OCR danger-zone flow (Clear -> Confirm/Cancel visible -> Cancel clicked, state reset cleanly; multi-row delete button renders with live selection count), Tax Obligations manual-entry form (Description/Notes accept input, Add Entry submit fires the expected "Amount must be greater than 0" validation with no data persisted), Tax Validation Refresh button (clears cache, re-runs, no errors). No duplicate-key or console errors observed; confirmed no key collisions exist elsewhere in the codebase.
- Sanity sweep (`git diff main...HEAD`): diff is exactly the 8 one-line `key=` additions, nothing else touched.
- **Note (out of scope, pre-existing):** while verifying, hit a live `TypeError: Modelo303Result.__init__() got an unexpected keyword argument 'box_28_iva_soportado'` crash on the Tax Obligations/Tax Validation tabs for the default 2026 Q1 selection — caused by a stale SQLite snapshot (`tax_computation_snapshots`) written before commit e08a3ff's M303 box rename, unrelated to this diff and confirmed to predate this branch. Filed separately as a bug issue; worked around it non-destructively for verification by switching the Quarter selector to Q2.

Closes #53