### PR TITLE
fix: tolerate and migrate stale pre-rename Modelo 303 snapshot keys

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -195,6 +195,48 @@ def backfill_invoice_classifications(conn: sqlite3.Connection) -> int:
     return updated
 
 
+# Pre-e08a3ff9 (#42) Modelo303Result field names -> current AEAT-casilla-matching
+# names. Mirrors src.tax_snapshot_codec._MODELO303_LEGACY_RENAMES; kept here too so
+# stale rows are rewritten in place at startup, not just tolerated on read.
+_MODELO303_LEGACY_SNAPSHOT_RENAMES: dict[str, str] = {
+    "box_28_iva_soportado": "box_29_cuota_soportado",
+    "box_29_base_soportado": "box_28_base_soportado",
+}
+
+
+def backfill_tax_snapshot_legacy_keys(conn: sqlite3.Connection) -> int:
+    """Rewrite Modelo 303 snapshot rows still using pre-rename box_28/29 keys.
+
+    Commit e08a3ff9 renamed ``Modelo303Result.box_28_iva_soportado`` to
+    ``box_29_cuota_soportado`` and ``box_29_base_soportado`` to
+    ``box_28_base_soportado``. Snapshots persisted before that rename still carry
+    the legacy keys in ``payload_json`` and fail to decode (``decode_snapshot``
+    tolerates this on read, but the stored row stays stale until rewritten here).
+    Returns the number of rows migrated.
+    """
+    rows = conn.execute(
+        "SELECT year, quarter, payload_json FROM tax_computation_snapshots WHERE model = '303'"
+    ).fetchall()
+    updated = 0
+    for row in rows:
+        data = json.loads(row["payload_json"])
+        if not any(old_key in data for old_key in _MODELO303_LEGACY_SNAPSHOT_RENAMES):
+            continue
+        for old_key, new_key in _MODELO303_LEGACY_SNAPSHOT_RENAMES.items():
+            if old_key in data:
+                data[new_key] = data.pop(old_key)
+        conn.execute(
+            """UPDATE tax_computation_snapshots SET payload_json = ?
+               WHERE year = ? AND quarter = ? AND model = '303'""",
+            (json.dumps(data, ensure_ascii=False), row["year"], row["quarter"]),
+        )
+        updated += 1
+    if updated:
+        conn.commit()
+        log.info("ℹ️ Migrated %d stale Modelo 303 snapshot row(s) to current box_28/29 field names", updated)
+    return updated
+
+
 def _ensure_audit_schema(conn: sqlite3.Connection) -> None:
     """Create the tax_audit_log table on existing DBs that predate it."""
     conn.execute("""
@@ -383,6 +425,7 @@ def init_db(db_path: Optional[str | Path] = None) -> None:
         _ensure_audit_schema(conn)
         conn.commit()
         backfill_invoice_classifications(conn)
+        backfill_tax_snapshot_legacy_keys(conn)
         log.info("ℹ️ Database initialised at %s", _DB_PATH)
     finally:
         conn.close()

--- a/src/tax_snapshot_codec.py
+++ b/src/tax_snapshot_codec.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict
+from dataclasses import asdict, fields
 from typing import Any
 
+from src.logger import get_logger
 from src.tax_models import (
     Modelo130Result,
     Modelo303Result,
@@ -16,12 +17,48 @@ from src.tax_models import (
     OSSReturnResult,
 )
 
+log = get_logger(__name__)
+
+# Pre-e08a3ff9 (#42) Modelo303Result field names -> current AEAT-casilla-matching
+# names. Snapshots persisted before that rename still carry these legacy keys in
+# ``payload_json`` and would otherwise raise a TypeError on decode.
+_MODELO303_LEGACY_RENAMES: dict[str, str] = {
+    "box_28_iva_soportado": "box_29_cuota_soportado",
+    "box_29_base_soportado": "box_28_base_soportado",
+}
+
 
 def _int_key_dict(d: dict[Any, Any]) -> dict[int, float]:
     out: dict[int, float] = {}
     for k, v in d.items():
         out[int(k)] = float(v)
     return out
+
+
+def _tolerant_construct(cls: type, data: dict[str, Any], legacy_renames: dict[str, str] | None = None) -> Any:
+    """Build a dataclass from stored snapshot data, tolerating legacy/unknown keys.
+
+    Applies ``legacy_renames`` first, then drops any remaining key that isn't a
+    field on ``cls`` (logging a warning) so a future field rename on a tax-engine
+    result dataclass can't hard-crash snapshot decoding the way ``box_28``/``box_29``
+    did after commit e08a3ff9.
+    """
+    data = dict(data)
+    for old_key, new_key in (legacy_renames or {}).items():
+        if old_key in data:
+            data[new_key] = data.pop(old_key)
+
+    known_fields = {f.name for f in fields(cls)}
+    unknown = sorted(set(data) - known_fields)
+    if unknown:
+        log.warning(
+            "⚠️ Dropping unknown legacy snapshot field(s) %s while decoding %s",
+            unknown, cls.__name__,
+        )
+        for key in unknown:
+            data.pop(key)
+
+    return cls(**data)
 
 
 def encode_snapshot(model: str, obj: Any) -> str:
@@ -39,9 +76,9 @@ def decode_snapshot(model: str, payload_json: str) -> Any:
     """Restore a computation result object from stored JSON."""
     data = json.loads(payload_json)
     if model == "303":
-        return Modelo303Result(**data)
+        return _tolerant_construct(Modelo303Result, data, _MODELO303_LEGACY_RENAMES)
     if model == "130":
-        return Modelo130Result(**data)
+        return _tolerant_construct(Modelo130Result, data)
     if model == "OSS":
         rows = [OSSCountryRow(**r) for r in data.get("rows", [])]
         return OSSReturnResult(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,19 +1,26 @@
 """Tests for the SQLite database layer."""
-import pytest
+import json
+import sqlite3
 from datetime import datetime
 
+import pytest
+
 from src.database import (
+    backfill_tax_snapshot_legacy_keys,
+    get_connection,
     get_latest_transaction_date,
     get_transaction_count_db,
     get_uploaded_files,
     init_db,
     load_classified_payments,
     load_payments,
+    load_tax_snapshots_for_period,
     record_upload,
     upsert_classified,
     upsert_payments,
 )
 from src.models import ClassifiedPayment, Payment
+from src.tax_snapshot_codec import decode_snapshot
 
 
 class TestDatabase:
@@ -167,3 +174,74 @@ class TestUploadLog:
 
         out_files = get_uploaded_files("out", db_path=tmp_db)
         assert len(out_files) == 1
+
+
+def _legacy_modelo303_payload() -> str:
+    """A Modelo 303 snapshot payload as it would have been written pre-e08a3ff9 (#42),
+    i.e. before box_28_iva_soportado -> box_29_cuota_soportado and
+    box_29_base_soportado -> box_28_base_soportado."""
+    return json.dumps({
+        "year": 2026, "quarter": 1,
+        "box_01_base": 100.0, "box_03_cuota": 21.0,
+        "box_59_intracom_entregas": 0.0,
+        "box_28_iva_soportado": 15.0,
+        "box_29_base_soportado": 60.0,
+        "box_46_diferencia": 6.0, "box_48_resultado": 6.0,
+        "oss_base": 0.0, "oss_vat": 0.0, "export_base": 0.0, "notes": "",
+    })
+
+
+class TestTaxSnapshotLegacyKeyMigration:
+    """Covers accounting-quarterly#58: stale pre-rename Modelo 303 snapshot rows
+    must not hard-crash the default Tax Obligations/Tax Validation view."""
+
+    def test_backfill_rewrites_legacy_keys_in_place(self, tmp_db):
+        init_db(tmp_db)
+        conn = get_connection(tmp_db)
+        conn.execute(
+            """INSERT INTO tax_computation_snapshots (year, quarter, model, payload_json, computed_at)
+               VALUES (2026, 1, '303', ?, '2026-01-01T00:00:00')""",
+            (_legacy_modelo303_payload(),),
+        )
+        conn.commit()
+
+        updated = backfill_tax_snapshot_legacy_keys(conn)
+        assert updated == 1
+
+        rows = load_tax_snapshots_for_period(2026, 1, conn)
+        payload = next(r["payload_json"] for r in rows if r["model"] == "303")
+        data = json.loads(payload)
+        assert "box_28_iva_soportado" not in data
+        assert "box_29_base_soportado" not in data
+        assert data["box_29_cuota_soportado"] == pytest.approx(15.0)
+        assert data["box_28_base_soportado"] == pytest.approx(60.0)
+        conn.close()
+
+    def test_init_db_migrates_stale_rows_on_startup(self, tmp_db):
+        init_db(tmp_db)
+        conn = get_connection(tmp_db)
+        conn.execute(
+            """INSERT INTO tax_computation_snapshots (year, quarter, model, payload_json, computed_at)
+               VALUES (2026, 1, '303', ?, '2026-01-01T00:00:00')""",
+            (_legacy_modelo303_payload(),),
+        )
+        conn.commit()
+        conn.close()
+
+        # Re-running init_db (as the app does on every startup) must self-heal
+        # the stale row so the default view decodes without a TypeError.
+        init_db(tmp_db)
+
+        conn = get_connection(tmp_db)
+        rows = load_tax_snapshots_for_period(2026, 1, conn)
+        payload = next(r["payload_json"] for r in rows if r["model"] == "303")
+        result = decode_snapshot("303", payload)
+        assert result.box_28_base_soportado == pytest.approx(60.0)
+        assert result.box_29_cuota_soportado == pytest.approx(15.0)
+        conn.close()
+
+    def test_decode_snapshot_tolerates_unmigrated_legacy_keys(self):
+        """Even without the startup migration, decode_snapshot alone must not crash."""
+        result = decode_snapshot("303", _legacy_modelo303_payload())
+        assert result.box_28_base_soportado == pytest.approx(60.0)
+        assert result.box_29_cuota_soportado == pytest.approx(15.0)


### PR DESCRIPTION
## Summary
- Commit e08a3ff9 (#42) renamed `Modelo303Result.box_28_iva_soportado` -> `box_29_cuota_soportado` and `box_29_base_soportado` -> `box_28_base_soportado`. Snapshot rows persisted before that rename still carried the legacy keys in `tax_computation_snapshots.payload_json`, so `decode_snapshot("303", ...)` raised `TypeError` on the default 2026-Q1 view — crashing the whole Streamlit script (Tax Obligations and Tax Validation render in the same script via `st.tabs()`, so one tab's exception took down the other).
- `decode_snapshot` now tolerates legacy/unknown keys: known-legacy Modelo 303 keys are renamed, and any other unexpected key is dropped with a warning log instead of crashing the dataclass constructor (same defensive path applied to Modelo 130 for future-proofing).
- `init_db()` now runs `backfill_tax_snapshot_legacy_keys()` at startup to rewrite stale Modelo 303 rows in place, so the on-disk snapshot is actually corrected, not just tolerated on read.

## Test plan
- [x] `.venv/Scripts/python.exe -m pytest -q` — 91 passed (added 3 new tests covering the backfill migration, startup self-heal, and tolerant decode of unmigrated legacy keys)
- [x] Ran `init_db()` against the real local `data/accounting.db` — confirmed it logged `Migrated 1 stale Modelo 303 snapshot row(s)` and the stored payload now uses `box_28_base_soportado`/`box_29_cuota_soportado`
- [x] Launched the Streamlit app and opened **Tax Obligations** on the default 2026-Q1 selection (no query params) — Modelo 303 sub-tab renders Box 28/29 values with no TypeError
- [x] Opened **Tax Validation** on the same run — renders Modelo 130/303/349/390 diff tables with no crash

Closes #58