### PR TITLE
refactor: dedupe AuditEntry construction and JSON-cache persistence

### DIFF
--- a/src/_json_store.py
+++ b/src/_json_store.py
@@ -1,0 +1,66 @@
+"""Shared in-memory-cached JSON file store.
+
+``src/config.py`` and ``src/rules_engine.py`` both persisted a single JSON
+file behind a module-level ``_cache | None`` with matching
+``load_/reload_/save_`` semantics — identical shape, different file path and
+missing-file handling. This module factors that pattern into one class so
+the load/reload/save semantics live in exactly one place.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+
+class JsonCache:
+    """In-memory cache over a single JSON file.
+
+    ``load``/``reload`` only actually read from disk when the in-memory
+    cache is empty (or on ``reload``, unconditionally); ``save`` writes
+    through and refreshes the cache. A ``path`` override is honoured only
+    while the cache is empty — matching the pre-existing per-module
+    behaviour where a cached value short-circuits any explicit path.
+
+    ``on_missing(resolved_path)``, if given, is called when the resolved
+    file doesn't exist and must return the dict to use in its place. If not
+    given, a missing file raises ``FileNotFoundError``.
+    """
+
+    def __init__(
+        self,
+        default_path: Path,
+        *,
+        on_missing: Optional[Callable[[Path], dict[str, Any]]] = None,
+    ) -> None:
+        self._default_path = default_path
+        self._on_missing = on_missing
+        self._cache: dict[str, Any] | None = None
+
+    def load(self, path: str | Path | None = None) -> dict[str, Any]:
+        if self._cache is not None:
+            return self._cache
+
+        resolved = Path(path) if path else self._default_path
+        if not resolved.exists():
+            if self._on_missing is not None:
+                return self._on_missing(resolved)
+            raise FileNotFoundError(f"File not found: {resolved}")
+
+        with open(resolved, encoding="utf-8") as f:
+            self._cache = json.load(f)
+        return self._cache
+
+    def reload(self, path: str | Path | None = None) -> dict[str, Any]:
+        self._cache = None
+        return self.load(path)
+
+    def save(self, data: dict[str, Any], path: str | Path | None = None) -> None:
+        resolved = Path(path) if path else self._default_path
+        with open(resolved, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        self._cache = data
+
+    def clear(self) -> None:
+        """Drop the in-memory cache without touching the file (test helper)."""
+        self._cache = None

--- a/src/config.py
+++ b/src/config.py
@@ -1,45 +1,34 @@
-import json
 import os
 from pathlib import Path
 from typing import Any
 
 from dotenv import load_dotenv
 
+from src._json_store import JsonCache
 from src.exceptions import ConfigError
 
 load_dotenv()
 
 _CONFIG_PATH = Path(__file__).parent.parent / "config.json"
-_config_cache: dict | None = None
+
+
+def _missing_config(path: Path) -> dict[str, Any]:
+    raise ConfigError(f"Config file not found: {path}")
+
+
+_cache = JsonCache(_CONFIG_PATH, on_missing=_missing_config)
 
 
 def load_config(path: str | Path | None = None) -> dict[str, Any]:
-    global _config_cache
-    if _config_cache is not None:
-        return _config_cache
-
-    cfg_path = Path(path) if path else _CONFIG_PATH
-    if not cfg_path.exists():
-        raise ConfigError(f"Config file not found: {cfg_path}")
-
-    with open(cfg_path, encoding="utf-8") as f:
-        _config_cache = json.load(f)
-
-    return _config_cache
+    return _cache.load(path)
 
 
 def reload_config(path: str | Path | None = None) -> dict[str, Any]:
-    global _config_cache
-    _config_cache = None
-    return load_config(path)
+    return _cache.reload(path)
 
 
 def save_config(cfg: dict[str, Any], path: str | Path | None = None) -> None:
-    cfg_path = Path(path) if path else _CONFIG_PATH
-    with open(cfg_path, "w", encoding="utf-8") as f:
-        json.dump(cfg, f, indent=2, ensure_ascii=False)
-    global _config_cache
-    _config_cache = cfg
+    _cache.save(cfg, path)
 
 
 def get_stripe_api_key() -> str:

--- a/src/rules_engine.py
+++ b/src/rules_engine.py
@@ -1,41 +1,37 @@
 """Classification rules engine that reads from classification_rules.json."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Optional
 
+from src._json_store import JsonCache
 from src.logger import get_logger
 
 log = get_logger(__name__)
 
 _RULES_PATH = Path(__file__).parent.parent / "classification_rules.json"
-_rules_cache: dict | None = None
+
+
+def _missing_rules(path: Path) -> dict[str, Any]:
+    log.warning("⚠️ classification_rules.json not found, using empty rules")
+    return {
+        "activity_rules": [],
+        "geographic_rules": {"defaults": {}, "geographic_overrides": {}, "email_overrides": {}},
+    }
+
+
+_cache = JsonCache(_RULES_PATH, on_missing=_missing_rules)
 
 
 def load_rules(path: Optional[str | Path] = None) -> dict[str, Any]:
-    global _rules_cache
-    if _rules_cache is not None:
-        return _rules_cache
-    rules_path = Path(path) if path else _RULES_PATH
-    if not rules_path.exists():
-        log.warning("⚠️ classification_rules.json not found, using empty rules")
-        return {"activity_rules": [], "geographic_rules": {"defaults": {}, "geographic_overrides": {}, "email_overrides": {}}}
-    with open(rules_path, encoding="utf-8") as f:
-        _rules_cache = json.load(f)
-    return _rules_cache
+    return _cache.load(path)
 
 
 def reload_rules(path: Optional[str | Path] = None) -> dict[str, Any]:
-    global _rules_cache
-    _rules_cache = None
-    return load_rules(path)
+    return _cache.reload(path)
 
 
 def save_rules(rules: dict[str, Any], path: Optional[str | Path] = None) -> None:
     rules_path = Path(path) if path else _RULES_PATH
-    with open(rules_path, "w", encoding="utf-8") as f:
-        json.dump(rules, f, indent=2, ensure_ascii=False)
-    global _rules_cache
-    _rules_cache = rules
+    _cache.save(rules, path)
     log.info("ℹ️ Classification rules saved to %s", rules_path)

--- a/src/tax_engine.py
+++ b/src/tax_engine.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import calendar
-import json
 import sqlite3
 from collections import defaultdict
 from datetime import date, datetime
+from functools import partial
 from typing import Optional
 
 from src.logger import get_logger
@@ -448,12 +448,7 @@ def compute_modelo_303(
     result.box_48_resultado = result.box_46_diferencia
 
     # --- Audit trail ---
-    def _a(cell, label, formula, value, **inputs):
-        return AuditEntry(
-            model="303", year=year, quarter=quarter,
-            cell=cell, label=label, formula=formula, value=value,
-            inputs_json=json.dumps(inputs),
-        )
+    _a = partial(AuditEntry.of, "303", year, quarter)
     result.audit = [
         _a("box_01_base",
            "Base imponible 21% (IVA devengado — Stripe + facturas emitidas España)",
@@ -617,12 +612,7 @@ def compute_modelo_130(
     )
 
     # --- Audit trail ---
-    def _a(cell, label, formula, value, **inputs):
-        return AuditEntry(
-            model="130", year=year, quarter=quarter,
-            cell=cell, label=label, formula=formula, value=value,
-            inputs_json=json.dumps(inputs),
-        )
+    _a = partial(AuditEntry.of, "130", year, quarter)
     # Build aggregated Stripe income records for audit trail (one per geo/activity bucket).
     # Mirrors the Quarter Report view the gestor uses.
     _stripe_agg: dict[tuple, dict] = {}
@@ -809,26 +799,23 @@ def compute_modelo_349(
         result.notes = "; ".join(warnings)
 
     # --- Audit trail ---
+    _a = partial(AuditEntry.of, "349", year, quarter)
     audit = []
     for r in result.rows:
-        audit.append(AuditEntry(
-            model="349", year=year, quarter=quarter,
-            cell=f"operator_{r.buyer_vat_id}",
-            label=f"Entregas intracomunitarias — {r.buyer_vat_id}",
-            formula="SUM(net_amount) for IVA_EU_B2B transactions grouped by buyer_vat_id",
-            value=r.total_amount,
-            inputs_json=json.dumps({"buyer_vat_id": r.buyer_vat_id, "buyer_name": r.buyer_name}),
+        audit.append(_a(
+            f"operator_{r.buyer_vat_id}",
+            f"Entregas intracomunitarias — {r.buyer_vat_id}",
+            "SUM(net_amount) for IVA_EU_B2B transactions grouped by buyer_vat_id",
+            r.total_amount,
+            buyer_vat_id=r.buyer_vat_id, buyer_name=r.buyer_name,
         ))
-    audit.append(AuditEntry(
-        model="349", year=year, quarter=quarter,
-        cell="total",
-        label="Total entregas intracomunitarias",
-        formula="SUM(total_amount) across all operators",
-        value=result.total,
-        inputs_json=json.dumps({
-            "operator_count": len(result.rows),
-            "negative_excluded": negative_excluded,
-        }),
+    audit.append(_a(
+        "total",
+        "Total entregas intracomunitarias",
+        "SUM(total_amount) across all operators",
+        result.total,
+        operator_count=len(result.rows),
+        negative_excluded=negative_excluded,
     ))
     result.audit = audit
     return result
@@ -844,14 +831,14 @@ def compute_oss_return(
     ``config`` is threaded through the VAT-treatment derivation.
     """
     result = OSSReturnResult(year=year, quarter=quarter)
+    _a = partial(AuditEntry.of, "OSS", year, quarter)
     if _tax_settings(config).get("oss_registered", True) is False:
-        result.audit = [AuditEntry(
-            model="OSS", year=year, quarter=quarter,
-            cell="oss_not_registered",
-            label="OSS no aplicable — no registrado en el régimen One Stop Shop",
-            formula="tax.oss_registered = false → no OSS return generated",
-            value=0.0,
-            inputs_json=json.dumps({"oss_registered": False}),
+        result.audit = [_a(
+            "oss_not_registered",
+            "OSS no aplicable — no registrado en el régimen One Stop Shop",
+            "tax.oss_registered = false → no OSS return generated",
+            0.0,
+            oss_registered=False,
         )]
         return result
     rows = _load_classified_for_quarter(year, quarter, db_conn)
@@ -887,41 +874,33 @@ def compute_oss_return(
     # --- Audit trail ---
     audit = []
     for r in result.rows:
-        audit.append(AuditEntry(
-            model="OSS", year=year, quarter=quarter,
-            cell=f"country_{r.country}_base",
-            label=f"OSS base — {r.country} ({int(r.vat_rate * 100)}%)",
-            formula="SUM(vat_base_eur) WHERE vat_treatment='OSS_EU' AND country=CC",
-            value=r.base_eur,
-            inputs_json=json.dumps({
-                "country": r.country, "vat_rate": r.vat_rate, "transactions": r.transactions,
-            }),
+        audit.append(_a(
+            f"country_{r.country}_base",
+            f"OSS base — {r.country} ({int(r.vat_rate * 100)}%)",
+            "SUM(vat_base_eur) WHERE vat_treatment='OSS_EU' AND country=CC",
+            r.base_eur,
+            country=r.country, vat_rate=r.vat_rate, transactions=r.transactions,
         ))
-        audit.append(AuditEntry(
-            model="OSS", year=year, quarter=quarter,
-            cell=f"country_{r.country}_vat",
-            label=f"OSS cuota — {r.country} ({int(r.vat_rate * 100)}%)",
-            formula=f"base_eur × {r.vat_rate}  [tasa país destino — OSS Reglamento (UE) 904/2010]",
-            value=r.vat_amount_eur,
-            inputs_json=json.dumps({
-                "country": r.country, "base_eur": r.base_eur, "vat_rate": r.vat_rate,
-            }),
+        audit.append(_a(
+            f"country_{r.country}_vat",
+            f"OSS cuota — {r.country} ({int(r.vat_rate * 100)}%)",
+            f"base_eur × {r.vat_rate}  [tasa país destino — OSS Reglamento (UE) 904/2010]",
+            r.vat_amount_eur,
+            country=r.country, base_eur=r.base_eur, vat_rate=r.vat_rate,
         ))
-    audit.append(AuditEntry(
-        model="OSS", year=year, quarter=quarter,
-        cell="total_base",
-        label="Base total OSS (todos los países)",
-        formula="SUM(base_eur) across all countries",
-        value=result.total_base,
-        inputs_json=json.dumps({"countries": len(result.rows), "transactions": result.total_transactions}),
+    audit.append(_a(
+        "total_base",
+        "Base total OSS (todos los países)",
+        "SUM(base_eur) across all countries",
+        result.total_base,
+        countries=len(result.rows), transactions=result.total_transactions,
     ))
-    audit.append(AuditEntry(
-        model="OSS", year=year, quarter=quarter,
-        cell="total_vat",
-        label="Cuota total OSS (todos los países)",
-        formula="SUM(vat_amount_eur) across all countries",
-        value=result.total_vat,
-        inputs_json=json.dumps({"total_base": result.total_base}),
+    audit.append(_a(
+        "total_vat",
+        "Cuota total OSS (todos los países)",
+        "SUM(vat_amount_eur) across all countries",
+        result.total_vat,
+        total_base=result.total_base,
     ))
     result.audit = audit
     return result
@@ -1001,31 +980,26 @@ def compute_modelo_347(year: int, db_conn: sqlite3.Connection) -> Modelo347Resul
     result.rows.sort(key=lambda r: r.total_operations, reverse=True)
 
     # --- Audit trail ---
+    _a = partial(AuditEntry.of, "347", year, 0)
     audit = []
     for r in result.rows:
-        audit.append(AuditEntry(
-            model="347", year=year, quarter=0,
-            cell=f"counterparty_{r.counterparty_name[:30]}",
-            label=f"Operaciones con {r.counterparty_name}",
-            formula=f"SUM(net_amount) WHERE geo_region='SPAIN' AND email_meta='{r.counterparty_name}' — threshold ≥ €{result.threshold:,.2f}",
-            value=r.total_operations,
-            inputs_json=json.dumps({
-                "counterparty": r.counterparty_name,
-                "quarter_breakdown": r.quarter_breakdown,
-            }),
+        audit.append(_a(
+            f"counterparty_{r.counterparty_name[:30]}",
+            f"Operaciones con {r.counterparty_name}",
+            f"SUM(net_amount) WHERE geo_region='SPAIN' AND email_meta='{r.counterparty_name}' — threshold ≥ €{result.threshold:,.2f}",
+            r.total_operations,
+            counterparty=r.counterparty_name,
+            quarter_breakdown=r.quarter_breakdown,
         ))
-    audit.append(AuditEntry(
-        model="347", year=year, quarter=0,
-        cell="summary",
-        label="Resumen Modelo 347",
-        formula=f"Counterparties >= €{result.threshold:,.2f} threshold",
-        value=float(len(result.rows)),
-        inputs_json=json.dumps({
-            "total_counterparties_spain": total_counterparties,
-            "above_threshold": len(result.rows),
-            "below_threshold": below_threshold,
-            "threshold_eur": result.threshold,
-        }),
+    audit.append(_a(
+        "summary",
+        "Resumen Modelo 347",
+        f"Counterparties >= €{result.threshold:,.2f} threshold",
+        float(len(result.rows)),
+        total_counterparties_spain=total_counterparties,
+        above_threshold=len(result.rows),
+        below_threshold=below_threshold,
+        threshold_eur=result.threshold,
     ))
     result.audit = audit
     return result

--- a/src/tax_models.py
+++ b/src/tax_models.py
@@ -160,3 +160,26 @@ class AuditEntry:
     formula: str          # text description of the formula/rule applied
     value: float          # computed value in EUR
     inputs_json: str = "" # JSON-serialised dict of named inputs for full traceability
+
+    @classmethod
+    def of(
+        cls,
+        model: str,
+        year: int,
+        quarter: int,
+        cell: str,
+        label: str,
+        formula: str,
+        value: float,
+        **inputs: Any,
+    ) -> "AuditEntry":
+        """Build an entry, JSON-serialising ``inputs`` into ``inputs_json``.
+
+        Single construction site for every ``compute_modelo_*`` function in
+        ``src/tax_engine.py`` — they all built the same shape by hand before.
+        """
+        return cls(
+            model=model, year=year, quarter=quarter,
+            cell=cell, label=label, formula=formula, value=value,
+            inputs_json=json.dumps(inputs),
+        )

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -28,10 +28,10 @@ class TestRulesEngine:
 
     def test_load_missing_file_returns_defaults(self, tmp_path):
         import src.rules_engine as re_mod
-        re_mod._rules_cache = None  # clear cache from prior tests
+        re_mod._cache.clear()  # clear cache from prior tests
         rules = load_rules(tmp_path / "nonexistent.json")
         assert rules["activity_rules"] == []
-        re_mod._rules_cache = None  # reset for other tests
+        re_mod._cache.clear()  # reset for other tests
 
     def test_geographic_rules_structure(self, tmp_rules):
         rules = load_rules(tmp_rules)


### PR DESCRIPTION
## Summary

- Adds `AuditEntry.of(model, year, quarter, cell, label, formula, value, **inputs)` as a classmethod on `src/tax_models.AuditEntry` — the single construction site for every audit-trail entry. Removes the two verbatim `_a(cell, label, formula, value, **inputs)` closures inside `compute_modelo_303` / `compute_modelo_130`, and every hand-rolled `AuditEntry(...)` + `json.dumps(inputs)` call in `compute_modelo_349`, `compute_oss_return`, and `compute_modelo_347`. Each call site now uses a `functools.partial(AuditEntry.of, model, year, quarter)` bound alias instead of a duplicated closure body.
- Extracts `src/_json_store.JsonCache` — the identical `_cache | None` + `load_/reload_/save_` triplet that `src/config.py` and `src/rules_engine.py` each reimplemented against their own JSON file (config.json / classification_rules.json), differing only in file path, cache variable name, and missing-file handling (raise `ConfigError` vs. log-and-return-defaults, injected via an `on_missing` callback).
- No behavior change: cache-short-circuits-path semantics, missing-file handling, and audit-entry field shapes are preserved exactly as before.

## Validation

- `& .\.venv\Scripts\python.exe -m py_compile src/tax_engine.py src/tax_models.py src/config.py src/rules_engine.py src/_json_store.py tests/test_rules_engine.py` — clean.
- `& .\.venv\Scripts\python.exe -m pytest -q` — 91 passed (full suite, including `test_tax_engine.py`'s Modelo 303/130/349/OSS/347 audit-trail assertions and `test_rules_engine.py`'s load/reload/save/missing-file cases).
- Manual probe (real temp files, not fixtures) exercising `config.py`/`rules_engine.py` end-to-end through the new shared `JsonCache`: missing-file → `ConfigError` / logged-default, load → mutate → save → reload round-trip, confirmed correct on both. Printed output confirmed by hand.
- `git diff` reviewed in full — no unrelated changes; the only test edit is updating `tests/test_rules_engine.py`'s cache-reset lines from the old module-level `_rules_cache` global to the new `_cache.clear()` (the internal representation the test was already reaching into).
- This repo has no `.github/workflows/` — CI not awaited (none configured).

Closes #51