### PR TITLE
docs: fix stale invoice OCR default paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,8 +543,8 @@ Configured via `config.json` (`invoice_in_dir` / `invoice_out_dir`). Both accept
 
 | Direction | Default path | Accounting role |
 |-----------|-------------|-----------------|
-| **In** (expenses) | `E:/.../invoices in` | Facturas recibidas — IVA soportado |
-| **Out** (income) | `E:/.../invoices out/archive` | Facturas emitidas — IVA repercutido |
+| **In** (expenses) | `data/invoices/in` | Facturas recibidas — IVA soportado |
+| **Out** (income) | `data/invoices/out` | Facturas emitidas — IVA repercutido |
 
 Re-extraction is skipped automatically when the PDF has not changed (MD5 hash comparison).
 


### PR DESCRIPTION
## Summary
- The "Invoice OCR" table's Default path column showed leftover personal paths (`E:/.../invoices in`, `E:/.../invoices out/archive`) for the `invoice_in_dir` / `invoice_out_dir` config keys.
- This contradicted `config.json.example` (`data/invoices/in` / `data/invoices/out`) and the README's own "Invoice Upload" section, which already documented the correct shipped defaults.
- Replaced the table's paths with `data/invoices/in` / `data/invoices/out` to match both sources of truth.

## Validation
- Docs-only change; no `.github/workflows` exist in this repo, so there is no CI to wait for.
- Confirmed the new values match `config.json.example:11-12` and the README's "Invoice Upload" section (line 497-499).
- Grepped the README for any other stale reference to the old paths — none found.
- Reviewed the full diff (`git diff main...HEAD`): scoped to exactly the two stale table cells.

Closes #63