### PR TITLE
fix: key compute_modelo_347 counterparties by NIF/VAT-ID first

### DIFF
--- a/src/tax_engine.py
+++ b/src/tax_engine.py
@@ -912,7 +912,7 @@ def compute_modelo_347(year: int, db_conn: sqlite3.Connection) -> Modelo347Resul
 
     # Stripe transactions from Spanish counterparties
     rows = db_conn.execute(
-        """SELECT email_meta, converted_amount, converted_amount_refunded, geo_region,
+        """SELECT email_meta, buyer_vat_id, converted_amount, converted_amount_refunded, geo_region,
                   strftime('%m', created_date) as month
            FROM transactions
            WHERE strftime('%Y', created_date) = ?
@@ -937,39 +937,54 @@ def compute_modelo_347(year: int, db_conn: sqlite3.Connection) -> Modelo347Resul
         (f"{year}-01-01", f"{year}-12-31"),
     ).fetchall()
 
-    by_email: dict[str, dict] = {}
+    # Both loops key by a normalised identity — NIF/VAT-ID first (the actual tax
+    # ID AEAT uses to identify a counterparty), falling back to a
+    # source-appropriate secondary identifier (email for Stripe, name for
+    # invoices) only when no NIF is on record. Mirrors compute_modelo_349's
+    # buyer_vat_id / client_nif keying so a counterparty known by the same NIF
+    # on both sides (a Stripe payment plus a manually-issued invoice)
+    # aggregates into one row instead of two separate below-threshold ones.
+    by_counterparty: dict[str, dict] = {}
     for row in rows:
+        nif = row["buyer_vat_id"] or ""
         email = row["email_meta"] or "UNKNOWN"
+        key = nif or email
         net = row["converted_amount"] - row["converted_amount_refunded"]
         month = int(row["month"])
         q = (month - 1) // 3 + 1
-        if email not in by_email:
-            by_email[email] = {"total": 0.0, "quarters": defaultdict(float), "nif": ""}
-        by_email[email]["total"] += net
-        by_email[email]["quarters"][q] += net
+        if key not in by_counterparty:
+            by_counterparty[key] = {"total": 0.0, "quarters": defaultdict(float), "nif": nif, "name": email}
+        by_counterparty[key]["total"] += net
+        by_counterparty[key]["quarters"][q] += net
+        if not by_counterparty[key]["nif"] and nif:
+            by_counterparty[key]["nif"] = nif
 
     for row in inv_rows:
-        counterparty = row["counterparty"]
+        nif = row["client_nif"] or ""
+        name = row["counterparty"]
+        key = nif or name
         net = row["subtotal_eur"] or 0.0
         month_str = row["month"]
         if not month_str:
             continue
         month = int(month_str)
         q = (month - 1) // 3 + 1
-        if counterparty not in by_email:
-            by_email[counterparty] = {"total": 0.0, "quarters": defaultdict(float), "nif": row["client_nif"] or ""}
-        by_email[counterparty]["total"] += net
-        by_email[counterparty]["quarters"][q] += net
-        if not by_email[counterparty]["nif"] and row["client_nif"]:
-            by_email[counterparty]["nif"] = row["client_nif"]
+        if key not in by_counterparty:
+            by_counterparty[key] = {"total": 0.0, "quarters": defaultdict(float), "nif": nif, "name": name}
+        by_counterparty[key]["total"] += net
+        by_counterparty[key]["quarters"][q] += net
+        if not by_counterparty[key]["nif"] and nif:
+            by_counterparty[key]["nif"] = nif
+        if by_counterparty[key]["name"] in ("", "UNKNOWN") and name not in ("", "UNKNOWN"):
+            by_counterparty[key]["name"] = name
 
-    total_counterparties = len(by_email)
+    total_counterparties = len(by_counterparty)
     below_threshold = 0
-    for email, info in by_email.items():
+    for key, info in by_counterparty.items():
         total = round(info["total"], 2)
         if total >= result.threshold:
             result.rows.append(Modelo347Row(
-                counterparty_name=email,
+                counterparty_name=info["name"] or key,
                 counterparty_nif=info.get("nif", ""),
                 total_operations=total,
                 quarter_breakdown={q: round(v, 2) for q, v in info["quarters"].items()},
@@ -983,12 +998,14 @@ def compute_modelo_347(year: int, db_conn: sqlite3.Connection) -> Modelo347Resul
     _a = partial(AuditEntry.of, "347", year, 0)
     audit = []
     for r in result.rows:
+        identity = r.counterparty_nif or r.counterparty_name
         audit.append(_a(
             f"counterparty_{r.counterparty_name[:30]}",
             f"Operaciones con {r.counterparty_name}",
-            f"SUM(net_amount) WHERE geo_region='SPAIN' AND email_meta='{r.counterparty_name}' — threshold ≥ €{result.threshold:,.2f}",
+            f"SUM(net_amount) WHERE geo_region='SPAIN' AND counterparty(nif||email/name)='{identity}' — threshold ≥ €{result.threshold:,.2f}",
             r.total_operations,
             counterparty=r.counterparty_name,
+            counterparty_nif=r.counterparty_nif,
             quarter_breakdown=r.quarter_breakdown,
         ))
     audit.append(_a(

--- a/tests/test_tax_engine.py
+++ b/tests/test_tax_engine.py
@@ -43,16 +43,48 @@ def _insert_tx(conn: sqlite3.Connection, **kwargs) -> None:
         vat_amount_eur=None,
         oss_country=None,
         buyer_vat_id=None,
+        email_meta=None,
     )
     defaults.update(kwargs)
     conn.execute(
         """INSERT OR REPLACE INTO transactions
            (id, created_date, converted_amount, converted_amount_refunded,
             description, fee, currency, activity_type, geo_region,
-            vat_treatment, vat_base_eur, vat_amount_eur, oss_country, buyer_vat_id)
+            vat_treatment, vat_base_eur, vat_amount_eur, oss_country, buyer_vat_id, email_meta)
            VALUES (:id, :created_date, :converted_amount, :converted_amount_refunded,
                    :description, :fee, :currency, :activity_type, :geo_region,
-                   :vat_treatment, :vat_base_eur, :vat_amount_eur, :oss_country, :buyer_vat_id)""",
+                   :vat_treatment, :vat_base_eur, :vat_amount_eur, :oss_country, :buyer_vat_id, :email_meta)""",
+        defaults,
+    )
+    conn.commit()
+
+
+def _insert_invoice(conn: sqlite3.Connection, **kwargs) -> None:
+    """Insert a minimal income (direction='out') invoice row for tax engine tests.
+
+    ``filename`` defaults to a value derived from ``id`` — the invoices table
+    has a ``UNIQUE(filename, direction)`` constraint, so two calls sharing a
+    literal default filename would silently replace each other via
+    ``INSERT OR REPLACE``.
+    """
+    defaults = dict(
+        id="inv_01",
+        filename=f"{kwargs.get('id', 'inv_01')}.pdf",
+        direction="out",
+        invoice_date="2025-01-15",
+        supply_date=None,
+        client_name=None,
+        client_nif=None,
+        subtotal_eur=100.0,
+        geo_region="SPAIN",
+    )
+    defaults.update(kwargs)
+    conn.execute(
+        """INSERT OR REPLACE INTO invoices
+           (id, filename, direction, invoice_date, supply_date,
+            client_name, client_nif, subtotal_eur, geo_region)
+           VALUES (:id, :filename, :direction, :invoice_date, :supply_date,
+                   :client_name, :client_nif, :subtotal_eur, :geo_region)""",
         defaults,
     )
     conn.commit()
@@ -237,6 +269,71 @@ class TestModelo349:
         assert len(result.rows) == 1
         assert result.rows[0].total_amount == pytest.approx(500.0)
         assert result.total == pytest.approx(500.0)
+
+
+class TestModelo347:
+    """Regression coverage for the by_email / by_counterparty keying bug
+    (accounting-quarterly#61): the Stripe loop and the invoice loop must key
+    by the same normalised identity (NIF/VAT-ID first, mirroring
+    compute_modelo_349's buyer_vat_id / client_nif pattern), or a single
+    real counterparty split across both channels silently escapes the
+    €3,005.06 threshold check.
+    """
+
+    def test_stripe_and_invoice_same_nif_consolidate_across_threshold(self, db_conn):
+        # Same counterparty (same NIF): one Stripe payment, one manually-issued
+        # invoice. Individually each is below the €3,005.06 threshold; only
+        # combined do they cross it — this is exactly the scenario the bug
+        # report describes.
+        _insert_tx(db_conn, id="t1", created_date="2025-02-01T10:00:00",
+                   converted_amount=2000.0, geo_region="SPAIN",
+                   activity_type="COACHING", buyer_vat_id="12345678Z")
+        _insert_invoice(db_conn, id="inv1", invoice_date="2025-05-01",
+                         client_name="Juan Perez", client_nif="12345678Z",
+                         subtotal_eur=1500.0)
+        result = compute_modelo_347(2025, db_conn)
+        assert len(result.rows) == 1
+        assert result.rows[0].counterparty_nif == "12345678Z"
+        assert result.rows[0].counterparty_name == "Juan Perez"
+        assert result.rows[0].total_operations == pytest.approx(3500.0)
+        assert sum(result.rows[0].quarter_breakdown.values()) == pytest.approx(3500.0)
+
+    def test_no_shared_nif_keeps_counterparties_separate(self, db_conn):
+        # No NIF on either side — a Stripe payer (keyed by email) and an
+        # invoice-only client (keyed by name) must NOT be merged just because
+        # neither has a NIF on record. Guards against over-correcting into a
+        # single-"UNKNOWN"-bucket regression.
+        _insert_tx(db_conn, id="t1", created_date="2025-01-10T10:00:00",
+                   converted_amount=4000.0, geo_region="SPAIN",
+                   activity_type="COACHING", email_meta="alice@example.com")
+        _insert_invoice(db_conn, id="inv1", invoice_date="2025-03-01",
+                         client_name="Bob Ltd", subtotal_eur=4000.0)
+        result = compute_modelo_347(2025, db_conn)
+        assert len(result.rows) == 2
+        totals = sorted(r.total_operations for r in result.rows)
+        assert totals == [pytest.approx(4000.0), pytest.approx(4000.0)]
+
+    def test_invoice_nif_consolidates_despite_name_spelling_drift(self, db_conn):
+        # Two invoices for the same NIF but slightly different client_name
+        # spellings must still consolidate into one row (NIF is the identity,
+        # not the free-text name).
+        _insert_invoice(db_conn, id="inv1", invoice_date="2025-01-15",
+                         client_name="Acme SL", client_nif="B87654321",
+                         subtotal_eur=1600.0)
+        _insert_invoice(db_conn, id="inv2", invoice_date="2025-04-15",
+                         client_name="ACME S.L.", client_nif="B87654321",
+                         subtotal_eur=1600.0)
+        result = compute_modelo_347(2025, db_conn)
+        assert len(result.rows) == 1
+        assert result.rows[0].counterparty_nif == "B87654321"
+        assert result.rows[0].total_operations == pytest.approx(3200.0)
+
+    def test_below_threshold_counterparty_excluded(self, db_conn):
+        _insert_tx(db_conn, id="t1", created_date="2025-01-10T10:00:00",
+                   converted_amount=500.0, geo_region="SPAIN",
+                   activity_type="COACHING", email_meta="small@example.com")
+        result = compute_modelo_347(2025, db_conn)
+        assert result.rows == []
 
 
 class TestConfigDrivenTaxSettings:


### PR DESCRIPTION
## Summary
- `compute_modelo_347`'s Stripe loop keyed by `email_meta` while its invoice loop keyed by `COALESCE(client_name, client_nif)` — two unrelated identity types for the same conceptual counterparty. A Spain counterparty who both pays via Stripe checkout and receives a manually-issued invoice was split into two separate below-threshold rows, so a counterparty who only crosses the €3,005.06 Modelo 347 threshold when both channels are combined could be silently omitted from the filing.
- Both loops now key by NIF/VAT-ID first (falling back to email for Stripe, name for invoices, only when no NIF is on record), mirroring `compute_modelo_349`'s existing `buyer_vat_id` / `client_nif` pattern.
- Added `TestModelo347` (no coverage existed for this function before) covering the cross-source merge, a no-shared-NIF non-merge guard, name-spelling-drift consolidation on the invoice side alone, and the existing below-threshold exclusion.
- Extended `_insert_tx` with `email_meta` and added an `_insert_invoice` test helper, both needed to exercise this path.

## Validation
- `pytest -v`: 95 passed, 0 failed (includes the 4 new `TestModelo347` regression tests).
- No `.github/workflows` in this repo, so there is no CI to await.
- Reviewed the full diff (`git diff main...HEAD`): scoped to `src/tax_engine.py` and `tests/test_tax_engine.py` only.

Closes #61