### PR TITLE
feat: add /close-quarter skill for the recurring quarterly-close workflow

### DIFF
--- a/.claude/skills/close-quarter/SKILL.md
+++ b/.claude/skills/close-quarter/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: close-quarter
+description: Guided quarterly close for the Stripe accounting dashboard — sweeps new invoice PDFs, verifies the Stripe import, fetches + classifies the quarter's transactions, walks through geo/activity overrides interactively, then regenerates the final Excel report. All outputs land in tmp/close_quarter/<year>_Q<quarter>/ (git-ignored) — nothing is sent or uploaded anywhere by this skill. Use for "/close-quarter", "close the quarter", "run the quarterly sweep", "prepare invoices for the accountant", "rerun the sweep".
+---
+
+# close-quarter
+
+**Goal:** walk the user through closing a Stripe accounting quarter, reusing
+the deterministic helper at `scripts/close_quarter.py` for every mechanical
+step, and pausing for the user's judgement at the points that actually need
+it (unreviewed invoices, ambiguous geo classification). Never do the
+mechanical steps by hand (inline Python, manually editing
+`classification_rules.json`) when the script already has a subcommand for it
+— the point of this skill is that the same procedure runs the same way every
+month.
+
+All commands run from the repo root with the project venv:
+`.venv/Scripts/python.exe scripts/close_quarter.py <subcommand> ...`
+(POSIX: `.venv/bin/python scripts/close_quarter.py ...`)
+
+## Arguments
+
+If the user passes `<year> Q<N>` (e.g. `/close-quarter 2026 Q3`), use that.
+Otherwise let the script default to the most recently completed calendar
+quarter (`close_quarter.py`'s `previous_quarter()`) and state which
+year/quarter you resolved to before doing anything else, so the user can
+correct it early.
+
+## Steps
+
+### 1. Sweep invoices
+
+Run `sweep --year Y --quarter Q`. It copies any received/sent invoice PDFs
+not yet copied or catalogued into `tmp/close_quarter/<Y>_Q<Q>/`, flattening
+subfolder paths into the filename (`IN - vendor - file.pdf` /
+`OUT - file.pdf`) and updating the cumulative manifest
+(`tmp/close_quarter/invoice_copy_log.json`) so a later re-run only picks up
+files added since.
+
+Report the counts and the list of newly copied files.
+
+**STOP.** Wait for the user to confirm before continuing — they may want to
+eyeball the folder, add more invoices, or tell you something's missing.
+
+### 2. Verify Stripe
+
+Run `stripe-check` (read-only, no DB writes). If it fails, report the error
+verbatim and stop — do not proceed to a full fetch on a broken connection.
+
+### 3. Fetch + classify
+
+Run `stripe-fetch --year Y --quarter Q`. This is a real write: it fetches
+the quarter's charges from Stripe, classifies them, and persists to the
+local SQLite DB (idempotent — safe to rerun). Show the user the totals and
+the full per-transaction table it prints, and call out the transactions it
+flagged with ⚠ (classified by a *default* geo rule — i.e. no client-specific
+override matched, so they're the ones most likely to be wrong).
+
+Ask: **"Any misclassifications to correct? Give me the client name/email and
+the correct region, or say it looks good."**
+
+### 4. Apply overrides (loop)
+
+For each correction the user gives:
+- Run `add-override "<key>" <REGION> --type name|email` (name = substring
+  matched against the transaction description; email = matched against
+  Stripe's email metadata — default to `name` unless the user's key is
+  clearly an email that appears in Stripe's separate email field rather than
+  in the description text).
+- Re-run `stripe-fetch --year Y --quarter Q` to reclassify with the updated
+  rule and persist it, and show the updated table + remaining flag count.
+
+Keep looping until the user confirms it's correct. Don't guess at a region
+from currency/card metadata yourself — always ask the user, since this is
+the one step that genuinely needs their judgement.
+
+### 5. Regenerate the report
+
+Once the user confirms the classification is correct, run
+`report --year Y --quarter Q`. This reads the now-corrected classification
+back from the DB and writes `Stripe_Report_Q<Q>_<Y>.xlsx` into the same
+`tmp/close_quarter/<Y>_Q<Q>/` folder as the swept invoices — one folder,
+ready to hand off.
+
+### 6. Summarize
+
+State the final folder path, the quarter's totals (income, fees, by
+activity/region), and remind the user explicitly that nothing has been sent
+or uploaded anywhere — `tmp/` is git-ignored and local only. Do not commit,
+push, or touch git as part of this skill.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Transaction data is fetched from the Stripe API and stored in the local SQLite d
 ├── config.json.example
 ├── requirements.txt
 ├── launch_app.bat                 # Windows launch shortcut
+├── scripts/
+│   └── close_quarter.py           # Deterministic quarterly-close helper (see "Closing a Quarter")
 ├── src/                           # Core business logic
 │   ├── models.py                  # Pydantic data models (Payment, ClassifiedPayment, ...)
 │   ├── config.py                  # Load/save config.json
@@ -130,8 +132,11 @@ Transaction data is fetched from the Stripe API and stored in the local SQLite d
 │       └── out/                   # Invoices produced (PDFs)
 ├── tmp/
 │   ├── social_security_bank_export.xlsx  # Bank export for SS cuotas (git-ignored, configurable)
-│   └── validation/
-│       └── validation.yaml        # Gestor-filed AEAT reference data (git-ignored)
+│   ├── validation/
+│   │   └── validation.yaml        # Gestor-filed AEAT reference data (git-ignored)
+│   └── close_quarter/             # Output of scripts/close_quarter.py (git-ignored)
+│       ├── invoice_copy_log.json  # Cumulative "already swept" invoice manifest
+│       └── <year>_Q<quarter>/     # Swept invoices + Stripe_Report_Q<quarter>_<year>.xlsx
 └── logs/                          # Rotating daily log files
 ```
 
@@ -226,6 +231,25 @@ Required permissions for restricted keys (`rk_live_...`):
 - **Read balance transactions** — fee details
 
 The dashboard includes a connection tester and permission checker under **Configuration → Stripe API**.
+
+---
+
+## Closing a Quarter
+
+`scripts/close_quarter.py` is the deterministic backbone for the recurring quarterly-close chore — invoked interactively via the `/close-quarter` Claude Code skill (`.claude/skills/close-quarter/`), which guides you through it step by step and pauses for confirmation/overrides at the points that need judgement. It can also be run by hand:
+
+```bash
+.venv/Scripts/python.exe scripts/close_quarter.py sweep [--year Y --quarter Q]         # copy new invoice PDFs
+.venv/Scripts/python.exe scripts/close_quarter.py stripe-check [--days N]              # read-only API smoke test
+.venv/Scripts/python.exe scripts/close_quarter.py stripe-fetch --year Y --quarter Q    # fetch + classify + persist
+.venv/Scripts/python.exe scripts/close_quarter.py add-override "<key>" REGION [--type email|name]
+.venv/Scripts/python.exe scripts/close_quarter.py report --year Y --quarter Q          # regenerate the Excel report
+```
+
+- **`sweep`** diffs `invoice_in_dir` / `invoice_out_dir` (recursively) against both the `invoices` DB table and a cumulative manifest (`tmp/close_quarter/invoice_copy_log.json`), copies only the files not seen before into `tmp/close_quarter/<year>_Q<quarter>/`, and updates the manifest — safe to rerun after adding more invoices.
+- **`stripe-fetch`** flags transactions classified by a *default* geo rule (no client-specific override matched) so they can be double-checked before the report goes out.
+- **`add-override`** appends to `classification_rules.json`'s `geographic_overrides` / `email_overrides` — the same mechanism as the Transaction Browser tab's "Add Geographic Override" form.
+- All output lives under `tmp/close_quarter/` (git-ignored) — nothing is uploaded or sent anywhere by this script.
 
 ---
 

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -48,6 +48,10 @@ flowchart TB
     TESTFILES["test_classifier · test_database · test_fx_rates ·\ntest_aggregator · test_rules_engine · test_models ·\ntest_tax_engine · test_tax_validator"]
   end
 
+  subgraph scripts["scripts/ — operational tooling"]
+    CLOSEQ["close_quarter.py\ninvoice sweep + Stripe fetch + Excel report\n(driven by /close-quarter skill, outputs to tmp/, git-ignored)"]
+  end
+
   STRIPE --> STRIPECLIENT
   FRANKFURTER --> FX
   HUB --> OCR
@@ -79,3 +83,8 @@ flowchart TB
 
   TESTFILES -.->|exercise| ingest
   TESTFILES -.->|exercise| taxcore
+
+  CLOSEQ --> STRIPECLIENT
+  CLOSEQ --> CLASSIFIER
+  CLOSEQ --> LOADER
+  CLOSEQ --> DB

--- a/scripts/close_quarter.py
+++ b/scripts/close_quarter.py
@@ -1,0 +1,232 @@
+"""Deterministic helper for closing a Stripe accounting quarter.
+
+Run from the repo root with the project venv:
+    .venv/Scripts/python.exe scripts/close_quarter.py <subcommand> [options]
+
+Subcommands:
+    sweep         Copy new invoice PDFs (received + sent) not yet copied or
+                  catalogued into tmp/close_quarter/<year>_Q<quarter>/, and
+                  update the cumulative copy-log manifest so re-runs only
+                  pick up files added since the last sweep.
+    stripe-check  Read-only Stripe API smoke test. No DB writes.
+    stripe-fetch  Fetch + classify + persist the target quarter's Stripe
+                  charges, then print a review table flagging transactions
+                  classified by a default geo rule (no client-specific
+                  override) so they can be double-checked.
+    add-override  Add a geographic classification override (name/email
+                  substring -> region) to classification_rules.json.
+    report        Regenerate the quarter's Excel report from the DB and
+                  save it into the same tmp/close_quarter/<year>_Q<quarter>/
+                  folder as the swept invoices.
+
+All outputs are written under tmp/, which is git-ignored.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+sys.stdout.reconfigure(encoding="utf-8")
+sys.stderr.reconfigure(encoding="utf-8")
+
+from src.config import load_config  # noqa: E402
+from src.rules_engine import load_rules, save_rules  # noqa: E402
+from src.stripe_client import fetch_charges  # noqa: E402
+
+# app.data_loader pulls in Streamlit (for @st.cache_data); import it lazily,
+# only inside the subcommands that actually need it, so `sweep` / `stripe-check`
+# / `add-override` stay free of Streamlit's "no runtime found" cache warning.
+
+MANIFEST_PATH = ROOT / "tmp" / "close_quarter" / "invoice_copy_log.json"
+DEFAULT_GEO_RULES = {"eur_default", "eur_newsletter_default", "non_eur_default"}
+
+
+def previous_quarter(today: datetime | None = None) -> tuple[int, int]:
+    """Return (year, quarter) for the most recently completed calendar quarter."""
+    today = today or datetime.now()
+    q = (today.month - 1) // 3 + 1
+    if q == 1:
+        return today.year - 1, 4
+    return today.year, q - 1
+
+
+def quarter_out_dir(year: int, quarter: int) -> Path:
+    d = ROOT / "tmp" / "close_quarter" / f"{year}_Q{quarter}"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _load_manifest() -> dict:
+    if MANIFEST_PATH.exists():
+        return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return {"in": [], "out": []}
+
+
+def _save_manifest(manifest: dict) -> None:
+    MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _relname(p: Path, base: Path) -> str:
+    return str(p.relative_to(base))
+
+
+def cmd_sweep(args: argparse.Namespace) -> None:
+    cfg = load_config()
+    in_dir = Path(cfg["app"]["invoice_in_dir"])
+    out_dir = Path(cfg["app"]["invoice_out_dir"])
+    dest = quarter_out_dir(args.year, args.quarter)
+
+    conn = sqlite3.connect(ROOT / "data" / "accounting.db")
+    conn.row_factory = sqlite3.Row
+    known_in = {r["filename"] for r in conn.execute("SELECT filename FROM invoices WHERE direction='in'")}
+    known_out = {r["filename"] for r in conn.execute("SELECT filename FROM invoices WHERE direction='out'")}
+    conn.close()
+
+    manifest = _load_manifest()
+    already_in = set(manifest.get("in", []))
+    already_out = set(manifest.get("out", []))
+
+    pdfs_in = sorted(in_dir.rglob("*.pdf")) if in_dir.exists() else []
+    pdfs_out = sorted(out_dir.rglob("*.pdf")) if out_dir.exists() else []
+
+    new_in = [p for p in pdfs_in
+              if _relname(p, in_dir) not in known_in and _relname(p, in_dir) not in already_in]
+    new_out = [p for p in pdfs_out
+               if _relname(p, out_dir) not in known_out and _relname(p, out_dir) not in already_out]
+
+    copied_in, copied_out = [], []
+    for p in new_in:
+        rel = _relname(p, in_dir)
+        dest_name = "IN - " + rel.replace("\\", " - ").replace("/", " - ")
+        shutil.copy2(p, dest / dest_name)
+        copied_in.append(rel)
+    for p in new_out:
+        rel = _relname(p, out_dir)
+        dest_name = "OUT - " + rel.replace("\\", " - ").replace("/", " - ")
+        shutil.copy2(p, dest / dest_name)
+        copied_out.append(rel)
+
+    manifest["in"] = sorted(already_in | set(copied_in))
+    manifest["out"] = sorted(already_out | set(copied_out))
+    manifest["last_run_at"] = datetime.now().isoformat(timespec="seconds")
+    _save_manifest(manifest)
+
+    print(f"Copied {len(copied_in)} received + {len(copied_out)} sent invoices -> {dest}")
+    for rel in copied_in:
+        print(f"  IN  {rel}")
+    for rel in copied_out:
+        print(f"  OUT {rel}")
+    if not copied_in and not copied_out:
+        print("No new invoices found.")
+
+
+def cmd_stripe_check(args: argparse.Namespace) -> None:
+    end = datetime.now()
+    start = end - timedelta(days=args.days)
+    payments = fetch_charges(start, end)
+    print(f"OK: Stripe API reachable, {len(payments)} charges in the last {args.days} days "
+          f"(read-only, no DB writes).")
+
+
+def cmd_stripe_fetch(args: argparse.Namespace) -> None:
+    from app.data_loader import get_classified_for_period, quarter_dates
+    from src.aggregator import calculate_grand_totals, get_transaction_count
+    from src.classifier import validate_classifications
+
+    start, end = quarter_dates(args.year, args.quarter)
+    payments = get_classified_for_period(
+        args.year, args.quarter, start, end,
+        input_mode="api",
+        force_refresh_token=datetime.now().isoformat(),
+    )
+    grand = calculate_grand_totals(payments)
+    counts = get_transaction_count(payments)
+    val = validate_classifications(payments)
+
+    print(f"Q{args.quarter} {args.year}: {len(payments)} transactions, "
+          f"{grand.get('total_income', 0):,.2f} EUR income, {grand.get('total_fee', 0):,.2f} EUR fees")
+    print(f"Validation: {val['activity_errors']} activity errors, {val['geo_errors']} geo errors, "
+          f"{val['unknown_activity']} unclassified")
+    print()
+    header = f"{'Date':<12} {'ID':<24} {'Amt EUR':>9} {'Activity':<14} {'Geo':<14} {'Geo rule':<28} {'Description'}"
+    print(header)
+    for p in sorted(payments, key=lambda x: x.created_date):
+        flag = " ⚠" if p.geo_rule in DEFAULT_GEO_RULES else ""
+        print(f"{p.created_date.strftime('%Y-%m-%d'):<12} {p.id:<24} {p.converted_amount:>9,.2f} "
+              f"{p.activity_type:<14} {p.geo_region:<14} {(p.geo_rule + flag):<28} {p.description[:40]}")
+    flagged = [p for p in payments if p.geo_rule in DEFAULT_GEO_RULES]
+    print()
+    print(f"{len(flagged)} transaction(s) on a DEFAULT geo rule (no client-specific override) "
+          f"— worth a manual check.")
+
+
+def cmd_add_override(args: argparse.Namespace) -> None:
+    rules = load_rules()
+    geo = rules.setdefault("geographic_rules", {})
+    key = args.key.strip().lower()
+    bucket = "email_overrides" if args.type == "email" else "geographic_overrides"
+    geo.setdefault(bucket, {})[key] = args.region
+    save_rules(rules)
+    print(f"Added override to {bucket}: {key!r} -> {args.region}")
+
+
+def cmd_report(args: argparse.Namespace) -> None:
+    from app.data_loader import get_classified_for_period, quarter_dates
+    from src.excel_exporter import create_excel_report, generate_report_filename
+
+    start, end = quarter_dates(args.year, args.quarter)
+    payments = get_classified_for_period(args.year, args.quarter, start, end, input_mode="db")
+    filename = generate_report_filename(args.year, args.quarter)
+    dest = quarter_out_dir(args.year, args.quarter) / filename
+    create_excel_report(payments, dest, args.year, args.quarter, f"Q{args.quarter}_{args.year}")
+    print(f"Saved: {dest}")
+
+
+def main() -> None:
+    default_year, default_quarter = previous_quarter()
+
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_yq(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--year", type=int, default=default_year)
+        p.add_argument("--quarter", type=int, default=default_quarter, choices=[1, 2, 3, 4])
+
+    p_sweep = sub.add_parser("sweep", help="Copy new invoice PDFs into the quarter's tmp folder")
+    add_yq(p_sweep)
+    p_sweep.set_defaults(func=cmd_sweep)
+
+    p_check = sub.add_parser("stripe-check", help="Read-only Stripe API smoke test")
+    p_check.add_argument("--days", type=int, default=90)
+    p_check.set_defaults(func=cmd_stripe_check)
+
+    p_fetch = sub.add_parser("stripe-fetch", help="Fetch + classify + persist the target quarter")
+    add_yq(p_fetch)
+    p_fetch.set_defaults(func=cmd_stripe_fetch)
+
+    p_override = sub.add_parser("add-override", help="Add a geographic classification override")
+    p_override.add_argument("key", help="Substring to match (client name or email)")
+    p_override.add_argument("region", choices=["SPAIN", "EU_NOT_SPAIN", "OUTSIDE_EU"])
+    p_override.add_argument("--type", choices=["name", "email"], default="name")
+    p_override.set_defaults(func=cmd_add_override)
+
+    p_report = sub.add_parser("report", help="Regenerate the quarter's Excel report")
+    add_yq(p_report)
+    p_report.set_defaults(func=cmd_report)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `scripts/close_quarter.py`: deterministic `sweep` / `stripe-check` / `stripe-fetch` / `add-override` / `report` subcommands, all output confined to `tmp/close_quarter/` (git-ignored)
- `.claude/skills/close-quarter/SKILL.md`: guides the interactive quarterly-close flow — sweep invoices, pause for review, verify + fetch Stripe, pause for geo-override corrections, regenerate the Excel report
- `README.md` + `docs/architecture.mmd` updated to document the new workflow

## Validation
- `pytest -q` — 95 passed
- `python -m py_compile scripts/close_quarter.py` — OK
- UX-conformance gate: `SPEC_APPLIES=no` (Streamlit spike, exempt)
- Manually ran `/close-quarter 2026 Q2` end to end against real data this session (invoice sweep, Stripe fetch/classify, geo-override corrections, report regeneration)

Closes #69