### PR TITLE
chore: ignore launcher-tmp scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ __pycache__
 .env
 config.json
 classification_rules.json
+# Launcher scratch (ephemeral images/logs written by the tray launcher)
+.launcher-tmp/


### PR DESCRIPTION
Backfill .launcher-tmp/ into the .gitignore so the app-launcher session host's ephemeral upload scratch dir doesn't get tracked when a session is rooted here.

Part of ferraroroberto/fleet-config#496